### PR TITLE
Refactor app to objects not globals

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 pylint = "*"
 ipython = "*"
 pytest = "*"
+flake8 = "*"
 
 [packages]
 python-dateutil = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aa02f525eed5e16c1d046d356bb085294e23789406572895b9d6b0ece5810e26"
+            "sha256": "7f01965cf466963eefef58824864ca1b2d7974a241d1be7c14e63d412b7c1be4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -33,20 +33,12 @@
         }
     },
     "develop": {
-        "appnope": {
-            "hashes": [
-                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
-                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
-            ],
-            "markers": "sys_platform == 'darwin'",
-            "version": "==0.1.0"
-        },
         "astroid": {
             "hashes": [
-                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
-                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
+                "sha256:0ef2bf9f07c3150929b25e8e61b5198c27b0dca195e156f0e4d5bdd89185ca1a",
+                "sha256:fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a"
             ],
-            "version": "==2.2.5"
+            "version": "==1.6.5"
         },
         "atomicwrites": {
             "hashes": [
@@ -62,12 +54,29 @@
             ],
             "version": "==19.1.0"
         },
-        "backcall": {
+        "backports.functools-lru-cache": {
             "hashes": [
-                "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
-                "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"
+                "sha256:9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a",
+                "sha256:f0b0e4eba956de51238e17573b7087e852dfe9854afd2e9c873f73fc0ca0a6dd"
             ],
-            "version": "==0.1.0"
+            "markers": "python_version < '3.2'",
+            "version": "==1.5"
+        },
+        "backports.shutil-get-terminal-size": {
+            "hashes": [
+                "sha256:0975ba55054c15e346944b38956a4c9cbee9009391e41b86c68990effb8c1f64",
+                "sha256:713e7a8228ae80341c70586d1cc0a8caa5207346927e23d09dcbcaf18eadec80"
+            ],
+            "markers": "python_version == '2.7'",
+            "version": "==1.0.0"
+        },
+        "configparser": {
+            "hashes": [
+                "sha256:8be81d89d6e7b4c0d4e44bcc525845f6da25821de80cb5e06e7e0238a2899e32",
+                "sha256:da60d0014fd8c55eb48c1c5354352e363e2d30bbf7057e5e171a468390184c75"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==3.7.4"
         },
         "decorator": {
             "hashes": [
@@ -76,13 +85,63 @@
             ],
             "version": "==4.4.0"
         },
-        "ipython": {
+        "entrypoints": {
             "hashes": [
-                "sha256:b038baa489c38f6d853a3cfc4c635b0cda66f2864d136fe8f40c1a6e334e2a6b",
-                "sha256:f5102c1cd67e399ec8ea66bcebe6e3968ea25a8977e53f012963e5affeb1fe38"
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+            ],
+            "version": "==0.3"
+        },
+        "enum34": {
+            "hashes": [
+                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
+                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
+                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
+            ],
+            "markers": "python_version < '3.4'",
+            "version": "==1.1.6"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661",
+                "sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8"
             ],
             "index": "pypi",
-            "version": "==7.4.0"
+            "version": "==3.7.7"
+        },
+        "funcsigs": {
+            "hashes": [
+                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
+                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+            ],
+            "markers": "python_version < '3.0'",
+            "version": "==1.0.2"
+        },
+        "functools32": {
+            "hashes": [
+                "sha256:89d824aa6c358c421a234d7f9ee0bd75933a67c29588ce50aaa3acdf4d403fa0",
+                "sha256:f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==3.2.3.post2"
+        },
+        "futures": {
+            "hashes": [
+                "sha256:9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265",
+                "sha256:ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==3.2.0"
+        },
+        "ipython": {
+            "hashes": [
+                "sha256:0371b7e4bd74954a35086eac949beeac5b1c9f5ce231e2e77df2286a293765e3",
+                "sha256:37101b8cbe072fe17bff100bc03d096404e4a9a0357097aeb5b61677c042cab1",
+                "sha256:4bac649857611baaaf76bc82c173aa542f7486446c335fe1a6c05d0d491c8906"
+            ],
+            "index": "pypi",
+            "version": "==5.8.0"
         },
         "ipython-genutils": {
             "hashes": [
@@ -97,13 +156,6 @@
                 "sha256:4e9e9c4bd1acd66cf6c36973f29b031ec752cbfd991c69695e4e259f9a756927"
             ],
             "version": "==4.3.16"
-        },
-        "jedi": {
-            "hashes": [
-                "sha256:2bb0603e3506f708e792c7f4ad8fc2a7a9d9c2d292a358fbbd58da531695595b",
-                "sha256:2c6bcd9545c7d6440951b12b44d373479bf18123a401a52025cf98563fbd826c"
-            ],
-            "version": "==0.13.3"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -148,18 +200,20 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
-                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
+                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
+                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
+                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
             ],
-            "markers": "python_version > '2.7'",
-            "version": "==7.0.0"
+            "markers": "python_version <= '2.7'",
+            "version": "==5.0.0"
         },
-        "parso": {
+        "pathlib2": {
             "hashes": [
-                "sha256:4580328ae3f548b358f4901e38c0578229186835f0fa0846e47369796dd5bcc9",
-                "sha256:68406ebd7eafe17f8e40e15a84b56848eccbf27d7c1feb89e93d8fca395706db"
+                "sha256:25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742",
+                "sha256:5887121d7f7df3603bca2f710e7219f3eca0eb69e0b7cc6e0a022e155ac931a7"
             ],
-            "version": "==0.3.4"
+            "markers": "python_version in '2.6 2.7 3.2 3.3'",
+            "version": "==2.3.3"
         },
         "pexpect": {
             "hashes": [
@@ -185,11 +239,11 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:11adf3389a996a6d45cc277580d0d53e8a5afd281d0c9ec71b28e6f121463780",
-                "sha256:2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1",
-                "sha256:977c6583ae813a37dc1c2e1b715892461fcbdaa57f6fc62f33a528c4886c8f55"
+                "sha256:1df952620eccb399c53ebb359cc7d9a8d3a9538cb34c5a1344bdbeb29fbcc381",
+                "sha256:3f473ae040ddaa52b52f97f6b4a493cfa9f5920c255a12dc56a7d34397a398a4",
+                "sha256:858588f1983ca497f1cf4ffde01d978a3ea02b01c8a26a8bbc5cd2e66d816917"
             ],
-            "version": "==2.0.9"
+            "version": "==1.0.15"
         },
         "ptyprocess": {
             "hashes": [
@@ -205,6 +259,20 @@
             ],
             "version": "==1.8.0"
         },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+            ],
+            "version": "==2.5.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+            ],
+            "version": "==2.1.1"
+        },
         "pygments": {
             "hashes": [
                 "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a",
@@ -214,19 +282,50 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
-                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
+                "sha256:02c2b6d268695a8b64ad61847f92e611e6afcff33fd26c3a2125370c4662905d",
+                "sha256:ee1e85575587c5b58ddafa25e1c1b01691ef172e139fc25585e5d3f02451da93"
             ],
             "index": "pypi",
-            "version": "==2.3.1"
+            "version": "==1.9.4"
         },
         "pytest": {
             "hashes": [
-                "sha256:592eaa2c33fae68c7d75aacf042efc9f77b27c08a6224a4f59beab8d9a420523",
-                "sha256:ad3ad5c450284819ecde191a654c09b0ec72257a2c711b9633d677c71c9850c4"
+                "sha256:13c5e9fb5ec5179995e9357111ab089af350d788cbc944c628f3cde72285809b",
+                "sha256:f21d2f1fb8200830dcbb5d8ec466a9c9120e20d8b53c7585d180125cce1d297a"
             ],
             "index": "pypi",
-            "version": "==4.3.1"
+            "version": "==4.4.0"
+        },
+        "scandir": {
+            "hashes": [
+                "sha256:2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e",
+                "sha256:2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022",
+                "sha256:2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f",
+                "sha256:2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f",
+                "sha256:4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae",
+                "sha256:67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173",
+                "sha256:7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4",
+                "sha256:8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32",
+                "sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188",
+                "sha256:b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d",
+                "sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"
+            ],
+            "markers": "python_version < '3.5'",
+            "version": "==1.10.0"
+        },
+        "simplegeneric": {
+            "hashes": [
+                "sha256:dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173"
+            ],
+            "version": "==0.8.1"
+        },
+        "singledispatch": {
+            "hashes": [
+                "sha256:5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c",
+                "sha256:833b46966687b3de7f438c761ac475213e53b306740f1abfaa86e1d1aae56aa8"
+            ],
+            "markers": "python_version < '3.4'",
+            "version": "==3.4.0.3"
         },
         "six": {
             "hashes": [
@@ -242,30 +341,14 @@
             ],
             "version": "==4.3.2"
         },
-        "typed-ast": {
+        "typing": {
             "hashes": [
-                "sha256:035a54ede6ce1380599b2ce57844c6554666522e376bd111eb940fbc7c3dad23",
-                "sha256:037c35f2741ce3a9ac0d55abfcd119133cbd821fffa4461397718287092d9d15",
-                "sha256:049feae7e9f180b64efacbdc36b3af64a00393a47be22fa9cb6794e68d4e73d3",
-                "sha256:19228f7940beafc1ba21a6e8e070e0b0bfd1457902a3a81709762b8b9039b88d",
-                "sha256:2ea681e91e3550a30c2265d2916f40a5f5d89b59469a20f3bad7d07adee0f7a6",
-                "sha256:3a6b0a78af298d82323660df5497bcea0f0a4a25a0b003afd0ce5af049bd1f60",
-                "sha256:5385da8f3b801014504df0852bf83524599df890387a3c2b17b7caa3d78b1773",
-                "sha256:606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424",
-                "sha256:69245b5b23bbf7fb242c9f8f08493e9ecd7711f063259aefffaeb90595d62287",
-                "sha256:6f6d839ab09830d59b7fa8fb6917023d8cb5498ee1f1dbd82d37db78eb76bc99",
-                "sha256:730888475f5ac0e37c1de4bd05eeb799fdb742697867f524dc8a4cd74bcecc23",
-                "sha256:9819b5162ffc121b9e334923c685b0d0826154e41dfe70b2ede2ce29034c71d8",
-                "sha256:9e60ef9426efab601dd9aa120e4ff560f4461cf8442e9c0a2b92548d52800699",
-                "sha256:af5fbdde0690c7da68e841d7fc2632345d570768ea7406a9434446d7b33b0ee1",
-                "sha256:b64efdbdf3bbb1377562c179f167f3bf301251411eb5ac77dec6b7d32bcda463",
-                "sha256:bac5f444c118aeb456fac1b0b5d14c6a71ea2a42069b09c176f75e9bd4c186f6",
-                "sha256:bda9068aafb73859491e13b99b682bd299c1b5fd50644d697533775828a28ee0",
-                "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
-                "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
+                "sha256:4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d",
+                "sha256:57dcf675a99b74d64dacf6fba08fb17cf7e3d5fdff53d4a30ea2a5e7e52543d4",
+                "sha256:a4c8473ce11a65999c8f59cb093e70686b6c84c98df58c1dae9b3b196089858a"
             ],
-            "markers": "implementation_name == 'cpython'",
-            "version": "==1.3.1"
+            "markers": "python_version < '3.5'",
+            "version": "==3.6.6"
         },
         "wcwidth": {
             "hashes": [

--- a/receptor/__init__.py
+++ b/receptor/__init__.py
@@ -1,89 +1,24 @@
-import importlib
-import configparser
 import os
 import uuid
 
-DEFAULT_CONFIG = dict(
-    server=dict(
-        port=8888,
-        address='0.0.0.0',
-        server_disable=False,
-    ),
-    peers=dict(),
-    components=dict(
-        security_manager='receptor.security.MallCop',
-        buffer_manager='receptor.buffers.memory.InMemoryBufferManager'
-    ),
-)
+from .config import ReceptorConfig
+from .router import MeshRouter
+from .work import WorkManager
 
 
-def py_class(class_spec):
-    if class_spec not in SINGLETONS:
-        module_name, class_name = class_spec.rsplit('.', 1)
-        module_obj = importlib.import_module(module_name)
-        class_obj = getattr(module_obj, class_name)
-        SINGLETONS[class_spec] = class_obj()
-    return SINGLETONS[class_spec]
+class Receptor:
+    def __init__(self, config=None, node_id=None, router_cls=None, 
+                 work_manager_cls=None):
+        self.config = config or ReceptorConfig()
+        self.node_id = node_id or config.receptor.node_id or self._find_node_id()
+        self.router = (router_cls or MeshRouter)(self)
+        self.work_manager = (work_manager_cls or WorkManager)(self)
 
-
-CAST_MAP = dict(
-    server=dict(
-        port=int,
-        server_disable=lambda val: val == "True",
-    ),
-    peers=dict(),
-    components=dict(
-        security_manager=py_class,
-        buffer_manager=py_class
-    )
-)
-
-
-VALUELESS_SECTIONS = ['peers']
-
-SINGLETONS = dict()
-
-
-class ReceptorConfigSection:
-    def __init__(self, parser, section):
-        self._parser = parser
-        self._section = section
-    
-    def __getattr__(self, key):
-        if not self._parser.has_section(self._section):
-            return None
-        to_return = self._parser.get(self._section, key)
-        cast_fn = CAST_MAP.get(self._section, {}).get(key, None)
-        if cast_fn:
-            return cast_fn(to_return)
-        return to_return
-
-
-class ReceptorConfig:
-    def __init__(self, config_path=None, cmdline_args=None):
-        self._parser = configparser.ConfigParser(allow_no_value=True, delimiters=('=',))
-        self._parser.read_dict(DEFAULT_CONFIG)
-        if config_path:
-            self._parser.read([config_path])
-        if cmdline_args:
-            self._parser.read_dict(cmdline_args)
-    
-    def __getattr__(self, key):
-        if key in VALUELESS_SECTIONS:
-            return list(dict(self._parser.items(key)).keys())
-        return ReceptorConfigSection(self._parser, key)
-
-
-config = ReceptorConfig()
-
-
-def get_node_id():
-    if config.receptor.node_id:
-        return config.receptor.node_id
-    if 'RECEPTOR_NODE_ID' not in os.environ:
+    def _find_node_id(self):
+        if 'RECEPTOR_NODE_ID' in os.environ:
+            return os.environ['RECEPTOR_NODE_ID']
+        
         node_id = uuid.uuid4()
-        os.environ['RECEPTOR_NODE_ID'] = str(node_id)
         if os.path.exists(os.path.join(os.getcwd(), 'Pipfile')):
             with open(os.path.join(os.getcwd(), '.env'), 'w+') as ofs:
                 ofs.write(f'\nRECEPTOR_NODE_ID={node_id}\n')
-    return os.environ['RECEPTOR_NODE_ID']

--- a/receptor/__main__.py
+++ b/receptor/__main__.py
@@ -1,8 +1,9 @@
 import argparse
 import logging
 import logging.config
+from .config import ReceptorConfig
 from .events import mainloop
-import receptor
+from receptor import Receptor
 
 logger = logging.getLogger(__name__)
 
@@ -57,9 +58,10 @@ def main(args=None):
             },
         }
     )
-    receptor.config = receptor.ReceptorConfig(args.config, map_args_to_config(args))
-    logger.info("Node Id: {}".format(receptor.get_node_id()))
-    mainloop(receptor.config)
+    config = ReceptorConfig(args.config, map_args_to_config(args))
+    receptor = Receptor(config)
+    logger.info("Node Id: {}".format(receptor.node_id))
+    mainloop(receptor)
 
 
 main()

--- a/receptor/config.py
+++ b/receptor/config.py
@@ -1,0 +1,69 @@
+import importlib
+import configparser
+
+DEFAULT_CONFIG = dict(
+    server=dict(
+        port=8888,
+        address='0.0.0.0',
+        server_disable=False,
+    ),
+    peers=dict(),
+    components=dict(
+        security_manager='receptor.security.MallCop',
+        buffer_manager='receptor.buffers.memory.InMemoryBufferManager'
+    ),
+)
+VALUELESS_SECTIONS = ['peers']
+SINGLETONS = {}
+
+
+def py_class(class_spec):
+    if class_spec not in SINGLETONS:
+        module_name, class_name = class_spec.rsplit('.', 1)
+        module_obj = importlib.import_module(module_name)
+        class_obj = getattr(module_obj, class_name)
+        SINGLETONS[class_spec] = class_obj()
+    return SINGLETONS[class_spec]
+
+
+CAST_MAP = dict(
+    server=dict(
+        port=int,
+        server_disable=lambda val: val == "True",
+    ),
+    peers=dict(),
+    components=dict(
+        security_manager=py_class,
+        buffer_manager=py_class
+    )
+)
+
+
+class ReceptorConfigSection:
+    def __init__(self, parser, section):
+        self._parser = parser
+        self._section = section
+    
+    def __getattr__(self, key):
+        if not self._parser.has_section(self._section):
+            return None
+        to_return = self._parser.get(self._section, key)
+        cast_fn = CAST_MAP.get(self._section, {}).get(key, None)
+        if cast_fn:
+            return cast_fn(to_return)
+        return to_return
+
+
+class ReceptorConfig:
+    def __init__(self, config_path=None, cmdline_args=None):
+        self._parser = configparser.ConfigParser(allow_no_value=True, delimiters=('=',))
+        self._parser.read_dict(DEFAULT_CONFIG)
+        if config_path:
+            self._parser.read([config_path])
+        if cmdline_args:
+            self._parser.read_dict(cmdline_args)
+    
+    def __getattr__(self, key):
+        if key in VALUELESS_SECTIONS:
+            return list(dict(self._parser.items(key)).keys())
+        return ReceptorConfigSection(self._parser, key)

--- a/receptor/events.py
+++ b/receptor/events.py
@@ -2,25 +2,25 @@ import asyncio
 import logging
 
 from .protocol import BasicProtocol, create_peer
-from .router import router
 
 logger = logging.getLogger(__name__)
 
 PING_INTERVAL = 15
 
 
-def mainloop(config):
+def mainloop(receptor):
     loop = asyncio.get_event_loop()
+    config = receptor.config
     if not config.server.server_disable:
         listener = loop.create_server(
-            lambda: BasicProtocol(loop),
+            lambda: BasicProtocol(receptor, loop),
             config.server.address, config.server.port)
         loop.create_task(listener)
         logger.info("Serving on %s:%s", config.server.address, config.server.port)
     for peer in config.peers:
-        loop.create_task(create_peer(*peer.split(":", 1), loop))
+        loop.create_task(create_peer(receptor, *peer.split(":", 1), loop))
     ping_time = (((int(loop.time()) + 1) // PING_INTERVAL) + 1) * PING_INTERVAL
-    loop.call_at(ping_time, loop.create_task, send_pings_and_reschedule(loop, ping_time))
+    loop.call_at(ping_time, loop.create_task, send_pings_and_reschedule(receptor, loop, ping_time))
     try:
         loop.run_forever()
     except KeyboardInterrupt:
@@ -29,10 +29,10 @@ def mainloop(config):
         loop.stop()
 
 
-async def send_pings_and_reschedule(loop, ping_time):
+async def send_pings_and_reschedule(receptor, loop, ping_time):
     logger.debug(f'Scheduling mesh ping.')
-    for node_id in router.get_nodes():
-        await router.ping_node(node_id)
+    for node_id in receptor.router.get_nodes():
+        await receptor.router.ping_node(node_id)
     loop.call_at(ping_time + PING_INTERVAL, 
                  loop.create_task, send_pings_and_reschedule(
-                     loop, ping_time + PING_INTERVAL))
+                     receptor, loop, ping_time + PING_INTERVAL))

--- a/receptor/handler.py
+++ b/receptor/handler.py
@@ -1,7 +1,5 @@
 import logging
 from .messages import envelope, directive
-from . import router
-from .work import work_manager
 from . import exceptions
 
 logger = logging.getLogger(__name__)
@@ -9,23 +7,23 @@ logger = logging.getLogger(__name__)
 RECEPTOR_DIRECTIVE_NAMESPACE = 'receptor'
 
 
-async def handle_msg(msg):
+async def handle_msg(receptor, msg):
     outer_env = envelope.OuterEnvelope.from_raw(msg)
-    next_hop = router.next_hop(outer_env.recipient)
+    next_hop = receptor.router.next_hop(outer_env.recipient)
     if next_hop is None:
-        await outer_env.deserialize_inner()
+        await outer_env.deserialize_inner(receptor)
         if outer_env.inner_obj.message_type == 'directive':
             namespace, _ = outer_env.inner_obj.directive.split(':', 1)
             if namespace == RECEPTOR_DIRECTIVE_NAMESPACE:
-                await directive.control(outer_env.inner_obj)
+                await directive.control(receptor.router, outer_env.inner_obj)
             else:
                 # other namespace/work directives
-                await work_manager.handle(outer_env.inner_obj)
+                await receptor.work_manager.handle(outer_env.inner_obj)
         elif outer_env.inner_obj.message_type == 'response':
             in_response_to = outer_env.inner_obj.in_response_to
-            if in_response_to in router.response_callback_registry:
+            if in_response_to in receptor.router.response_callback_registry:
                 logger.info(f'Handling response to {in_response_to} with callback.')
-                callback = router.response_callback_registry[in_response_to]
+                callback = receptor.router.response_callback_registry[in_response_to]
                 await callback(outer_env.inner_obj)
             else:
                 logger.warning(f'Received response to {in_response_to} but no callback registered!')
@@ -33,5 +31,5 @@ async def handle_msg(msg):
             raise exceptions.UnknownMessageType(
                 f'Unknown message type: {outer_env.inner_obj.message_type}')
     else:
-        await router.forward(outer_env, next_hop)
+        await receptor.router.forward(outer_env, next_hop)
 

--- a/receptor/messages/directive.py
+++ b/receptor/messages/directive.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 
 from ..exceptions import UnknownDirective
-from .. import router
 from . import envelope
 
 logger = logging.getLogger(__name__)
@@ -17,7 +16,7 @@ class Directive:
 class Control:
     CONTROL_DIRECTIVES = ['ping']
 
-    async def __call__(self, inner_env):
+    async def __call__(self, router, inner_env):
         _, action = inner_env.directive.split(':', 1)
         if action not in self.CONTROL_DIRECTIVES:
             raise UnknownDirective(f'Unknown control directive: {action}')
@@ -27,6 +26,7 @@ class Control:
         async for response in responses:
             serial += 1
             enveloped_response = envelope.InnerEnvelope.make_response(
+                receptor=router.receptor,
                 recipient=inner_env.sender,
                 payload=response,
                 in_response_to=inner_env.message_id,

--- a/receptor/work.py
+++ b/receptor/work.py
@@ -3,11 +3,13 @@ import logging
 
 from . import exceptions
 from .messages import envelope
-from . import router
 logger = logging.getLogger(__name__)
 
 
 class WorkManager:
+    def __init__(self, receptor):
+        self.receptor = receptor
+
     async def handle(self, inner_env):
         logger.info(f'Handling work for {inner_env.message_id} as {inner_env.directive}')
         namespace, action = inner_env.directive.split(':', 1)
@@ -27,12 +29,12 @@ class WorkManager:
             serial += 1
             logger.debug(f'Response emitted for {inner_env.message_id}, serial {serial}')
             enveloped_response = envelope.InnerEnvelope.make_response(
+                receptor=self.receptor,
                 recipient=inner_env.sender,
                 payload=response,
                 in_response_to=inner_env.message_id,
                 serial=serial
             )
-            await router.send(enveloped_response)
+            await self.receptor.router.send(enveloped_response)
 
 
-work_manager = WorkManager()


### PR DESCRIPTION
Instead of tracking state using global variables and object instances, compartmentalize the instance of a receptor into a single object to track state & configuration. This should improve testability too.