### PR TITLE
Make ping count/delay configurable

### DIFF
--- a/receptor/config.py
+++ b/receptor/config.py
@@ -183,6 +183,20 @@ class ReceptorConfig:
         )
         self.add_config_option(
             section='ping',
+            key='count',
+            default_value=0,
+            value_type='int',
+            hint='Number of pings to send. If unspecified here or in a config file pings will be continuously sent until interrupted.',
+        )
+        self.add_config_option(
+            section='ping',
+            key='delay',
+            default_value=0,
+            value_type='float',
+            hint='The delay (in seconds) to wait between pings. If unspecified here or in a config file pings will be sent as soon as the previous response is received.',
+        )
+        self.add_config_option(
+            section='ping',
             key='recipient',
             long_option='ping_recipient',
             default_value='',
@@ -360,6 +374,8 @@ class ReceptorConfig:
                 return value_type(value)
             elif value_type == 'int' and not isinstance(value, int):
                 return int(value)
+            elif value_type == 'float' and not isinstance(value, float):
+                return float(value)
             elif value_type == 'str' and not isinstance(value, str):
                 return '%s' % (value,)
             elif value_type == 'bool' and not isinstance(value, bool):

--- a/receptor/controller.py
+++ b/receptor/controller.py
@@ -19,7 +19,13 @@ def send_directive(directive, recipient, payload, sock):
         payload = sys.stdin.read()
     sock.sendall(f"{recipient}\n{directive}\n{payload}".encode('utf-8') + protocol.DELIM)
     response = b''
-    response = sock.recv(4096)
+    while True:
+        received = sock.recv(1024)
+        done = protocol.DELIM in received
+        response += received.rstrip(protocol.DELIM)
+        if done:
+            break
+            
     return response
 
 # FIXME: the socket path is in the config, it shouldn't need to be passed as an arg here

--- a/receptor/controller.py
+++ b/receptor/controller.py
@@ -1,25 +1,27 @@
 import asyncio
 import logging
+import os
 import socket
 import sys
-import os
 
 from . import protocol
 
 logger = logging.getLogger(__name__)
 
 
-def send_directive(directive, recipient, payload, socket_path):
+def send_directive(directive, recipient, payload, socket_path, expected_responses=1):
     if payload == '-':
         payload = sys.stdin.read()
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.connect(socket_path)
     sock.sendall(f"{recipient}\n{directive}\n{payload}".encode('utf-8') + protocol.DELIM)
     response = b''
-    while True:
+    response_count = 0
+    while response_count < expected_responses:
         response = sock.recv(4096)
         sys.stdout.buffer.write(response + b"\n")
         sys.stdout.flush()
+        response_count += 1
 
 # FIXME: the socket path is in the config, it shouldn't need to be passed as an arg here
 def mainloop(receptor, socket_path, loop=asyncio.get_event_loop()):

--- a/receptor/controller.py
+++ b/receptor/controller.py
@@ -9,19 +9,18 @@ from . import protocol
 logger = logging.getLogger(__name__)
 
 
-def send_directive(directive, recipient, payload, socket_path, expected_responses=1):
-    if payload == '-':
-        payload = sys.stdin.read()
+def connect_to_socket(socket_path):
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.connect(socket_path)
+    return sock
+
+def send_directive(directive, recipient, payload, sock):
+    if payload == '-':
+        payload = sys.stdin.read()
     sock.sendall(f"{recipient}\n{directive}\n{payload}".encode('utf-8') + protocol.DELIM)
     response = b''
-    response_count = 0
-    while response_count < expected_responses:
-        response = sock.recv(4096)
-        sys.stdout.buffer.write(response + b"\n")
-        sys.stdout.flush()
-        response_count += 1
+    response = sock.recv(4096)
+    return response
 
 # FIXME: the socket path is in the config, it shouldn't need to be passed as an arg here
 def mainloop(receptor, socket_path, loop=asyncio.get_event_loop()):

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import time
 
 from .receptor import Receptor
 from . import node
@@ -17,7 +18,14 @@ def run_as_controller(config):
 def run_as_ping(config):
     logger.info(f'Sending ping to {config.ping_recipient}.')
     now = datetime.datetime.utcnow()
-    controller.send_directive('receptor:ping', config.ping_recipient, now.isoformat(), config.ping_socket_path)
+    pings_sent = 0
+    while True:
+        controller.send_directive('receptor:ping', config.ping_recipient, now.isoformat(), config.ping_socket_path)
+        pings_sent += 1
+        if config.ping_count != 0 and pings_sent >= config.ping_count:
+            break
+        elif config.ping_delay > 0.0:
+            time.sleep(config.ping_delay)
 
 
 def run_as_send(config):

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -17,6 +17,12 @@ def run_as_controller(config):
     controller.mainloop(receptor, config.controller_socket_path)
 
 
+def run_as_node(config):
+    receptor = Receptor(config)
+    logger.info(f'Running as Receptor node with ID: {receptor.node_id}')
+    node.mainloop(receptor, config.node_ping_interval)
+
+
 def run_as_ping(config):
     logger.info(f'Sending ping to {config.ping_recipient}.')
     sock = controller.connect_to_socket(config.ping_socket_path)
@@ -28,7 +34,7 @@ def run_as_ping(config):
             response = controller.send_directive('receptor:ping', config.ping_recipient, now.isoformat(), sock)
             resp_json = json.loads(response)
             if 'code' in resp_json and resp_json['code'] != 0:
-                sys.stdout.buffer.write(b"Failed to ping node: %b\n" % (resp_json['payload'].encode('utf-8'),))
+                sys.stdout.buffer.write(b"Failed to ping node: %b\n" % (resp_json['raw_payload'].encode('utf-8'),))
             else:
                 sys.stdout.buffer.write(response + b"\n")
             sys.stdout.flush()
@@ -54,9 +60,3 @@ def run_as_send(config):
         pass
     finally:
         sock.close()
-
-
-def run_as_node(config):
-    receptor = Receptor(config)
-    logger.info(f'Running as Receptor node with ID: {receptor.node_id}')
-    node.mainloop(receptor, config.node_ping_interval)

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -28,7 +28,7 @@ def run_as_ping(config):
             response = controller.send_directive('receptor:ping', config.ping_recipient, now.isoformat(), sock)
             resp_json = json.loads(response)
             if 'code' in resp_json and resp_json['code'] != 0:
-                sys.stdout.buffer.write(b"Failed to ping node.\n")
+                sys.stdout.buffer.write(b"Failed to ping node: %b\n" % (resp_json['payload'].encode('utf-8'),))
             else:
                 sys.stdout.buffer.write(response + b"\n")
             sys.stdout.flush()

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -1,5 +1,7 @@
 import datetime
+import json
 import logging
+import sys
 import time
 
 from .receptor import Receptor
@@ -17,20 +19,41 @@ def run_as_controller(config):
 
 def run_as_ping(config):
     logger.info(f'Sending ping to {config.ping_recipient}.')
-    now = datetime.datetime.utcnow()
-    pings_sent = 0
-    while True:
-        controller.send_directive('receptor:ping', config.ping_recipient, now.isoformat(), config.ping_socket_path)
-        pings_sent += 1
-        if config.ping_count != 0 and pings_sent >= config.ping_count:
-            break
-        elif config.ping_delay > 0.0:
-            time.sleep(config.ping_delay)
+    sock = controller.connect_to_socket(config.ping_socket_path)
+
+    try:
+        pings_sent = 0
+        while True:
+            now = datetime.datetime.utcnow()
+            response = controller.send_directive('receptor:ping', config.ping_recipient, now.isoformat(), sock)
+            resp_json = json.loads(response)
+            if 'code' in resp_json and resp_json['code'] != 0:
+                sys.stdout.buffer.write(b"Failed to ping node.\n")
+            else:
+                sys.stdout.buffer.write(response + b"\n")
+            sys.stdout.flush()
+            pings_sent += 1
+            if config.ping_count != 0 and pings_sent >= config.ping_count:
+                break
+            elif config.ping_delay > 0.0:
+                time.sleep(config.ping_delay)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        sock.close()
 
 
 def run_as_send(config):
     logger.info(f'Sending a {config.send_directive} directive to {config.send_recipient}.')
-    controller.send_directive(config.send_directive, config.send_recipient, config.send_payload, config.send_socket_path)
+    sock = controller.connect_to_socket(config.send_socket_path)
+    try:
+        response = controller.send_directive(config.send_directive, config.send_recipient, config.send_payload, sock)
+        sys.stdout.buffer.write(response + b"\n")
+        sys.stdout.flush()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        sock.close()
 
 
 def run_as_node(config):

--- a/receptor/protocol.py
+++ b/receptor/protocol.py
@@ -7,6 +7,7 @@ import time
 import uuid
 
 from collections import deque
+
 from .messages import envelope
 from .exceptions import ReceptorBufferError
 
@@ -172,7 +173,7 @@ class BasicControllerProtocol(asyncio.Protocol):
         self.transport.write(json.dumps(dict(timestamp=response.timestamp,
                                              in_response_to=response.in_response_to,
                                              payload=response.raw_payload,
-                                             code=response.code)).encode())
+                                             code=response.code)).encode() + DELIM)
 
     def data_received(self, data):
         recipient, directive, payload = data.rstrip(DELIM).decode('utf8').split('\n', 2)
@@ -212,6 +213,6 @@ class BasicControllerProtocol(asyncio.Protocol):
                         payload=str(e),
                         code=1,
                     )
-                ).encode()
+                ).encode() + DELIM
             )
 


### PR DESCRIPTION
Make ping count/delay configurable
    
* Adds `float` type to allowed value types
* Modifies `entrypoints.run_as_ping` to use new config options
* Modifies controller.send_directive` to use a new param named `expected_responses`, which allows us to stop waiting for more responses after the set # is received (defaults to 1 response)
