### PR TITLE
Handle missing subcommand gracefully

### DIFF
--- a/receptor/config.py
+++ b/receptor/config.py
@@ -404,6 +404,8 @@ class ReceptorConfig:
     def go(self):
         if not self._parsed_args:
             raise ReceptorRuntimeError("there are no parsed args yet")
+        elif not hasattr(self._parsed_args, 'subparser_name'):
+            raise ReceptorRuntimeError("you must specify a subcommand (%s)." % (", ".join(SUBCOMMAND_EXTRAS.keys()),))
         self._parsed_args.func(self)
 
 


### PR DESCRIPTION
### before
```
[jamesc@jimi receptor]$ python3 -m receptor 
An error occured while running receptor:
'Namespace' object has no attribute 'func'
```
### after
```
[jamesc@jimi receptor]$ python3 -m receptor 
An error occured while running receptor:
you must specify a subcommand (node, controller, ping, send).
```