### PR TITLE
Add tests to verify stats reported by receptor

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -24,6 +24,7 @@ jobs:
         python ./test/perf/node_utils.py file ./test/perf/topology-random.yaml&
         python ./test/perf/node_utils.py dot-compare graph_controller.dot last-topology_graph.dot --wait 40
         python ./test/perf/node_utils.py ping ./test/perf/topology-random.yaml --count 100 --validate 0.1
+        python ./test/perf/node_utils.py check-stats last-topology.yaml
         kill `pidof python`
         rm -Rf /tmp/receptor
         rm graph_controller.dot
@@ -38,6 +39,7 @@ jobs:
         python ./test/perf/node_utils.py file ./test/perf/topology-flat.yaml&
         python ./test/perf/node_utils.py dot-compare graph_controller.dot last-topology_graph.dot --wait 40
         python ./test/perf/node_utils.py ping ./test/perf/topology-flat.yaml --count 100 --validate 0.1
+        python ./test/perf/node_utils.py check-stats last-topology.yaml
         kill `pidof python`
         rm -Rf /tmp/receptor
         rm graph_controller.dot
@@ -52,6 +54,7 @@ jobs:
         python ./test/perf/node_utils.py file ./test/perf/topology-tree.yaml&
         python ./test/perf/node_utils.py dot-compare graph_controller.dot last-topology_graph.dot --wait 40
         python ./test/perf/node_utils.py ping ./test/perf/topology-tree.yaml --count 100 --validate 0.1
+        python ./test/perf/node_utils.py check-stats last-topology.yaml
         kill `pidof python`
         rm -Rf /tmp/receptor
         rm graph_controller.dot

--- a/test/perf/requirements.txt
+++ b/test/perf/requirements.txt
@@ -1,3 +1,4 @@
 click
-pyyaml
 pyparsing
+pyyaml
+requests

--- a/test/perf/topology-flat.yaml
+++ b/test/perf/topology-flat.yaml
@@ -4,75 +4,101 @@ nodes:
     controller: true
     listen_port: 8888
     name: controller
+    stats_enable: true
+    stats_port: null
   node1:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node1
+    stats_enable: true
+    stats_port: null
   node10:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node10
+    stats_enable: true
+    stats_port: null
   node11:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node11
+    stats_enable: true
+    stats_port: null
   node12:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node12
+    stats_enable: true
+    stats_port: null
   node2:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node2
+    stats_enable: true
+    stats_port: null
   node3:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node3
+    stats_enable: true
+    stats_port: null
   node4:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node4
+    stats_enable: true
+    stats_port: null
   node5:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node5
+    stats_enable: true
+    stats_port: null
   node6:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node6
+    stats_enable: true
+    stats_port: null
   node7:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node7
+    stats_enable: true
+    stats_port: null
   node8:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node8
+    stats_enable: true
+    stats_port: null
   node9:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node9
+    stats_enable: true
+    stats_port: null

--- a/test/perf/topology-random.yaml
+++ b/test/perf/topology-random.yaml
@@ -4,12 +4,16 @@ nodes:
     controller: true
     listen_port: 8888
     name: controller
+    stats_enable: true
+    stats_port: null
   node1:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node1
+    stats_enable: true
+    stats_port: null
   node10:
     connections:
     - node12
@@ -17,12 +21,16 @@ nodes:
     controller: false
     listen_port: null
     name: node10
+    stats_enable: true
+    stats_port: null
   node11:
     connections:
     - node1
     controller: false
     listen_port: null
     name: node11
+    stats_enable: true
+    stats_port: null
   node12:
     connections:
     - node11
@@ -30,12 +38,16 @@ nodes:
     controller: false
     listen_port: null
     name: node12
+    stats_enable: true
+    stats_port: null
   node2:
     connections:
     - node1
     controller: false
     listen_port: null
     name: node2
+    stats_enable: true
+    stats_port: null
   node3:
     connections:
     - node6
@@ -43,6 +55,8 @@ nodes:
     controller: false
     listen_port: null
     name: node3
+    stats_enable: true
+    stats_port: null
   node4:
     connections:
     - node7
@@ -50,6 +64,8 @@ nodes:
     controller: false
     listen_port: null
     name: node4
+    stats_enable: true
+    stats_port: null
   node5:
     connections:
     - node8
@@ -57,6 +73,8 @@ nodes:
     controller: false
     listen_port: null
     name: node5
+    stats_enable: true
+    stats_port: null
   node6:
     connections:
     - node10
@@ -64,6 +82,8 @@ nodes:
     controller: false
     listen_port: null
     name: node6
+    stats_enable: true
+    stats_port: null
   node7:
     connections:
     - node3
@@ -71,12 +91,16 @@ nodes:
     controller: false
     listen_port: null
     name: node7
+    stats_enable: true
+    stats_port: null
   node8:
     connections:
     - node1
     controller: false
     listen_port: null
     name: node8
+    stats_enable: true
+    stats_port: null
   node9:
     connections:
     - node10
@@ -84,3 +108,5 @@ nodes:
     controller: false
     listen_port: null
     name: node9
+    stats_enable: true
+    stats_port: null

--- a/test/perf/topology-tree.yaml
+++ b/test/perf/topology-tree.yaml
@@ -4,75 +4,101 @@ nodes:
     controller: true
     listen_port: 8888
     name: controller
+    stats_enable: true
+    stats_port: null
   node1:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node1
+    stats_enable: true
+    stats_port: null
   node10:
     connections:
     - node9
     controller: false
     listen_port: null
     name: node10
+    stats_enable: true
+    stats_port: null
   node11:
     connections:
     - node9
     controller: false
     listen_port: null
     name: node11
+    stats_enable: true
+    stats_port: null
   node12:
     connections:
     - node9
     controller: false
     listen_port: null
     name: node12
+    stats_enable: true
+    stats_port: null
   node2:
     connections:
     - node1
     controller: false
     listen_port: null
     name: node2
+    stats_enable: true
+    stats_port: null
   node3:
     connections:
     - node1
     controller: false
     listen_port: null
     name: node3
+    stats_enable: true
+    stats_port: null
   node4:
     connections:
     - node1
     controller: false
     listen_port: null
     name: node4
+    stats_enable: true
+    stats_port: null
   node5:
     connections:
       - controller
     controller: false
     listen_port: null
     name: node5
+    stats_enable: true
+    stats_port: null
   node6:
     connections:
     - node5
     controller: false
     listen_port: null
     name: node6
+    stats_enable: true
+    stats_port: null
   node7:
     connections:
     - node5
     controller: false
     listen_port: null
     name: node7
+    stats_enable: true
+    stats_port: null
   node8:
     connections:
     - node5
     controller: false
     listen_port: null
     name: node8
+    stats_enable: true
+    stats_port: null
   node9:
     connections:
     - controller
     controller: false
     listen_port: null
     name: node9
+    stats_enable: true
+    stats_port: null


### PR DESCRIPTION
Add tests to verify that stats reported by receptor are accurate.
Currently tests only check for the expected number of connected nodes.