### PR TITLE
Make memory-based payload work

### DIFF
--- a/receptor/controller.py
+++ b/receptor/controller.py
@@ -42,6 +42,7 @@ class Controller:
 
     async def send(self, message, expect_response=True):
         new_id = uuid.uuid4()
+        message.fd.seek(0)
         inner_env = envelope.Inner(
             receptor=self.receptor,
             message_id=str(new_id),

--- a/receptor/messages/envelope.py
+++ b/receptor/messages/envelope.py
@@ -21,7 +21,7 @@ class Message:
     __slots__ = ("fd", "recipient", "directive")
 
     def __init__(self, recipient, directive):
-        self.fd = io.BytesIO()
+        self.fd = io.StringIO()
         self.recipient = recipient
         self.directive = directive
 


### PR DESCRIPTION
Message payloads either specified as a string on the command line command line, or supplied via the Python API as a non-file, do not work because (a) the file descriptor is not at the beginning when send() is called, and (b) the BytesIO object uses bytes rather than str which is unexpected in the json serializer when signing the message.  This change switches to StringIO and also rewinds the file descriptor immediately prior to sending.