### PR TITLE
Keep ssl context on reconnect

### DIFF
--- a/receptor/connection/ws.py
+++ b/receptor/connection/ws.py
@@ -42,7 +42,7 @@ async def connect(uri, factory, loop=None, ssl_context=None):
     finally:
         await asyncio.sleep(5)
         logger.debug("ws.connect: reconnecting")
-        loop.create_task(connect(uri, factory=factory, loop=loop))
+        loop.create_task(connect(uri, factory=factory, loop=loop, ssl_context=ssl_context))
 
 
 async def serve(request, factory):


### PR DESCRIPTION
Mutual TLS fails on reconnect because SSL context is lost.