### PR TITLE
Ignore files created by affinity test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ venv.bak/
 # mypy
 .mypy_cache/
 graph_*.dot
+
+# Created by affinity test framework
+/.last-mesh.yaml


### PR DESCRIPTION
`affinity.py` creates a file that presumably exists for debugging and
testing purposes, and should not be committed:

```console
$ git grep last-topology
test/perf/affinity.py:    def dump_yaml(self, filename=".last-topology.yaml"):
```