### PR TITLE
Make subprocess invocation safer

### DIFF
--- a/test/perf/affinity.py
+++ b/test/perf/affinity.py
@@ -181,10 +181,7 @@ class Node:
         ]
         print(starter)
         start = time.time()
-        op = subprocess.Popen(
-            " ".join(starter), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        op.wait()
+        op = subprocess.run(starter, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         duration = time.time() - start
         cmd_output = op.stdout.readlines()
         print(op.stderr.read())


### PR DESCRIPTION
This is **NOT SAFE**:

```python
subprocess.Popen('echo foo&rm -rf /').wait()
```

This is safe:

```python
subprocess.Popen(('echo', 'foo&rm -rf /')).wait()
```