### PR TITLE
Fix Message class behavior and file descriptor handling

### DIFF
--- a/receptor/messages/envelope.py
+++ b/receptor/messages/envelope.py
@@ -26,14 +26,15 @@ class Message:
         self.directive = directive
 
     def open(self):
+        self.fd.seek(0)
         return self.fd
 
     def file(self, path):
-        self.fd = open(path)
+        self.fd = open(path, 'r+b')
 
     def buffer(self, buffered_io):
-        if not isinstance(buffered_io, io.IOBase):
-            raise ReceptorRuntimeError("buffer must be of type IOBase")
+        if not isinstance(buffered_io, io.BytesIO):
+            raise ReceptorRuntimeError("buffer must be of type io.BytesIO")
         self.fd = buffered_io
 
     def data(self, raw_data):

--- a/receptor/tests/test_message.py
+++ b/receptor/tests/test_message.py
@@ -1,0 +1,41 @@
+import pytest
+import os
+import io
+from tempfile import mkstemp
+from receptor.messages.envelope import Message
+from receptor.exceptions import ReceptorRuntimeError
+
+
+@pytest.yield_fixture
+def afile():
+    f = mkstemp()
+    yield f
+    os.remove(f[1])
+
+
+def test_message_file_handling(afile):
+    os.write(afile[0], b"test")
+    m = Message("receipient", "test")
+    m.file(afile[1])
+    assert m.open().read() == b"test"
+
+
+def test_message_data_handling():
+    m = Message("receipient", "test")
+    m.data(b"test")
+    assert m.open().read() == b"test"
+
+    with pytest.raises(TypeError):
+        m.data("test")
+        assert m.open().read() == b"test"
+
+
+def test_message_buffer_handling():
+    m = Message("receipient", "test")
+    i = io.BytesIO(b"test")
+    m.buffer(i)
+    assert m.open().read() == b"test"
+
+    with pytest.raises(ReceptorRuntimeError):
+        i = io.StringIO("test")
+        m.buffer(i)


### PR DESCRIPTION
* Enforce byte usage over strings
* Ensure a file is opened with r+b
* Force a seek to the beginning of the file handle when a file is given

This should fix #105 