### PR TITLE
Fix payload input data types

### DIFF
--- a/receptor/controller.py
+++ b/receptor/controller.py
@@ -50,7 +50,7 @@ class Controller:
             message_type="directive",
             directive=message.directive,
             timestamp=datetime.datetime.utcnow().isoformat(),
-            raw_payload=message.fd.read(),
+            raw_payload=message.open().read(),
         )
         await self.receptor.router.send(inner_env, expected_response=expect_response)
         return new_id

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -92,11 +92,15 @@ def run_as_send(config):
             await asyncio.sleep(0.1)
         msg = Message(config.send_recipient, config.send_directive)
         if config.send_payload == "-":
-            msg.buffer(sys.stdin)
+            msg.data(sys.stdin.buffer.read())
         elif os.path.exists(config.send_payload):
             msg.file(config.send_payload)
         else:
-            msg.data(config.send_payload)
+            if isinstance(config.send_payload, str):
+                send_payload = config.send_payload.encode()
+            else:
+                send_payload = config.send_payload
+            msg.data(send_payload)
         await controller.send(msg)
         await read_task
 

--- a/receptor/router.py
+++ b/receptor/router.py
@@ -154,7 +154,6 @@ class MeshRouter:
             # TODO: This probably needs to emit an error response
             raise UnrouteableError(f'No route found to {inner_envelope.recipient}')
         signed = await inner_envelope.sign_and_serialize()
-
         header = {
             "sender": self.node_id,
             "recipient": inner_envelope.recipient,


### PR DESCRIPTION
The raw data payload inputs need to be coerced into bytes if they aren't already in that format
this makes sure that everything is consistently passed as bytes from the Controller and entrypoints