### PR TITLE
Add a status command

### DIFF
--- a/receptor/config.py
+++ b/receptor/config.py
@@ -5,7 +5,7 @@ import logging
 import os
 import ssl
 
-from .entrypoints import run_as_node, run_as_ping, run_as_send, run_as_controller
+from .entrypoints import run_as_node, run_as_ping, run_as_send, run_as_controller, run_as_status
 from .exceptions import ReceptorRuntimeError, ReceptorConfigError
 
 logger = logging.getLogger(__name__)
@@ -27,6 +27,10 @@ SUBCOMMAND_EXTRAS = {
     'send': {
         'hint': 'Send a directive to a node',
         'entrypoint': run_as_send,
+    },
+    'status': {
+        'hint': 'Display status of the Receptor network',
+        'entrypoint': run_as_status,
     },
 }
 
@@ -194,6 +198,13 @@ class ReceptorConfig:
             default_value='',
             value_type='str',
             hint='The peer to relay the ping directive through'
+        )
+        self.add_config_option(
+            section='status',
+            key='peer',
+            default_value='',
+            value_type='str',
+            hint='The peer to access the mesh through'
         )
         self.add_config_option(
             section='controller',

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -125,8 +125,7 @@ def run_as_status(config):
         print("  Others:", ", ".join(list(controller.receptor.router.get_nodes())))
         print("Edges:")
         for edge in controller.receptor.router.get_edges():
-           print("  ", edge)
+            print("  ", edge)
 
     controller = Controller(config)
     controller.run(status_entrypoint)
-

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -111,3 +111,22 @@ def run_as_send(config):
     logger.info(f'Sending directive {config.send_directive} to {config.send_recipient} via {config.send_peer}')
     controller = Controller(config)
     controller.run(send_entrypoint)
+
+
+def run_as_status(config):
+
+    async def status_entrypoint():
+        controller.add_peer(config.status_peer)
+        start_wait = time.time()
+        while not controller.receptor.router.node_is_known(config.status_peer) and (time.time() - start_wait < 5):
+            await asyncio.sleep(0.1)
+        print("Nodes:")
+        print("  Myself:", controller.receptor.router.node_id)
+        print("  Others:", ", ".join(list(controller.receptor.router.get_nodes())))
+        print("Edges:")
+        for edge in controller.receptor.router.get_edges():
+           print("  ", edge)
+
+    controller = Controller(config)
+    controller.run(status_entrypoint)
+


### PR DESCRIPTION
Adds a crude version of a status command that shows what other nodes have joined the mesh and how they are interconnected.  In future maybe this would include an option to show work queue depths at the nodes, or other potentially useful information.