### PR TITLE
Worker thread pool and command line changes

### DIFF
--- a/receptor/buffers/file.py
+++ b/receptor/buffers/file.py
@@ -140,6 +140,6 @@ class FileBufferManager(BaseBufferManager):
         # make sure we only construct a single instance of DurableBuffer
         # per-node so.. doing this the hard way.
         if node_id not in self._buffers:
-            path = os.path.join(os.path.expanduser(receptor.config.default_data_dir))
+            path = os.path.join(os.path.expanduser(receptor.base_path))
             self._buffers[node_id] = DurableBuffer(path, node_id, asyncio.get_event_loop())
         return self._buffers[node_id]

--- a/receptor/config.py
+++ b/receptor/config.py
@@ -15,22 +15,27 @@ SUBCOMMAND_EXTRAS = {
     'node': {
         'hint': 'Run a Receptor node',
         'entrypoint': run_as_node,
+        'is_ephemeral': False,
     },
     'controller': {
         'hint': 'Run a Receptor controller',
         'entrypoint': run_as_controller,  # TODO: New entrypoint
+        'is_ephemeral': False,
     },
     'ping': {
         'hint': 'Tell the local controller to ping a node',
         'entrypoint': run_as_ping,
+        'is_ephemeral': True,
     },
     'send': {
         'hint': 'Send a directive to a node',
         'entrypoint': run_as_send,
+        'is_ephemeral': True,
     },
     'status': {
         'hint': 'Display status of the Receptor network',
         'entrypoint': run_as_status,
+        'is_ephemeral': True,
     },
 }
 
@@ -79,7 +84,7 @@ class ReceptorConfig:
             section='default',
             key='data_dir',
             short_option='-d',
-            default_value='/var/lib/receptor',
+            default_value=None,
             value_type='path',
             hint='Path to the directory where Receptor stores its database and metadata.',
         )
@@ -91,6 +96,14 @@ class ReceptorConfig:
             value_type='bool',
             hint='Emit debugging output.',
         )
+        default_max_workers = min(32, os.cpu_count() + 4)
+        self.add_config_option(
+            section='default',
+            key='max_workers',
+            default_value=default_max_workers,
+            value_type='int',
+            hint='Size of the thread pool for worker threads. If unspecified, defaults to {}'.format(default_max_workers),
+        ),
         # Auth section options. This is a new section for the config file only,
         # so all of these options use `subparse=False`.
         self.add_config_option(
@@ -195,16 +208,16 @@ class ReceptorConfig:
         self.add_config_option(
             section='ping',
             key='peer',
-            default_value='',
+            default_value='localhost:8888',
             value_type='str',
-            hint='The peer to relay the ping directive through'
+            hint='The peer to relay the ping directive through. If unspecified here or in a config file, localhost:8888 will be used.'
         )
         self.add_config_option(
             section='status',
             key='peer',
-            default_value='',
+            default_value='localhost:8888',
             value_type='str',
-            hint='The peer to access the mesh through'
+            hint='The peer to access the mesh through. If unspecified here or in a config file, localhost:8888 will be used.'
         )
         self.add_config_option(
             section='controller',
@@ -224,17 +237,17 @@ class ReceptorConfig:
         self.add_config_option(
             section='ping',
             key='count',
-            default_value=0,
+            default_value=4,
             value_type='int',
-            hint='Number of pings to send. If unspecified here or in a config file pings will be continuously sent until interrupted.',
+            hint='Number of pings to send. If set to zero, pings will be continuously sent until interrupted.',
         )
         self.add_config_option(
             section='ping',
             key='delay',
-            default_value=0,
+            default_value=1,
             value_type='float',
-            hint='The delay (in seconds) to wait between pings. If unspecified here or in a'
-                 'config file pings will be sent as soon as the previous response is received.',
+            hint='The delay (in seconds) to wait between pings. If set to zero,'
+                 'pings will be sent as soon as the previous response is received.',
         )
         self.add_config_option(
             section='ping',
@@ -248,9 +261,9 @@ class ReceptorConfig:
         self.add_config_option(
             section='send',
             key='peer',
-            default_value='',
+            default_value='localhost:8888',
             value_type='str',
-            hint='The peer to relay the directive through'
+            hint='The peer to relay the directive through. If unspecified here or in a config file, localhost:8888 will be used.'
         )
         self.add_config_option(
             section='send',
@@ -344,6 +357,7 @@ class ReceptorConfig:
                     if sub_extra:
                         subparser = self._cli_sub_args.add_parser(section, help=sub_extra['hint'])
                         subparser.set_defaults(func=sub_extra['entrypoint'])
+                        subparser.set_defaults(is_ephemeral=sub_extra['is_ephemeral'])
                 subparser.add_argument(*args, **kwargs)
 
         # finally, we add the ConfigOption to the internal dict for tracking
@@ -403,6 +417,12 @@ class ReceptorConfig:
         if self._config_file:
             for section in filter(lambda x: x.startswith("plugin_"), self._config_file.sections()):
                 self._config_options['plugins'][section.replace("plugin_", "")] = dict(self._config_file[section])
+        # If we did not get a data_dir from anywhere else, use a default
+        if self._config_options['default_data_dir'].value is None:
+            if hasattr(self._parsed_args, 'is_ephemeral') and self._parsed_args.is_ephemeral:
+                self._config_options['default_data_dir'].value = '/tmp/receptor'
+            else:
+                self._config_options['default_data_dir'].value = '/var/lib/receptor'
 
     def _enforce_entry_type(self, entry):
         if entry.value is not None:

--- a/receptor/config.py
+++ b/receptor/config.py
@@ -358,7 +358,7 @@ class ReceptorConfig:
                     if sub_extra:
                         subparser = self._cli_sub_args.add_parser(section, help=sub_extra['hint'])
                         subparser.set_defaults(func=sub_extra['entrypoint'])
-                        self._is_ephemeral = sub_extra['is_ephemeral']
+                        subparser.set_defaults(ephemeral=sub_extra['is_ephemeral'])
                 subparser.add_argument(*args, **kwargs)
 
         # finally, we add the ConfigOption to the internal dict for tracking
@@ -473,6 +473,7 @@ class ReceptorConfig:
             raise ReceptorRuntimeError("there are no parsed args yet")
         elif not hasattr(self._parsed_args, 'func'):
             raise ReceptorRuntimeError("you must specify a subcommand (%s)." % (", ".join(SUBCOMMAND_EXTRAS.keys()),))
+        self._is_ephemeral = self._parsed_args.ephemeral
         self._parsed_args.func(self)
 
     def get_client_ssl_context(self):

--- a/receptor/config.py
+++ b/receptor/config.py
@@ -63,6 +63,7 @@ class ReceptorConfig:
         self._cli_sub_args = self._cli_args.add_subparsers()
         self._parsed_args = None
         self._config_file = configparser.ConfigParser(allow_no_value=True, delimiters=('=',))
+        self._is_ephemeral = False
 
         # Default options, which apply to all sub-commands.
         self.add_config_option(
@@ -357,7 +358,7 @@ class ReceptorConfig:
                     if sub_extra:
                         subparser = self._cli_sub_args.add_parser(section, help=sub_extra['hint'])
                         subparser.set_defaults(func=sub_extra['entrypoint'])
-                        subparser.set_defaults(is_ephemeral=sub_extra['is_ephemeral'])
+                        self._is_ephemeral = sub_extra['is_ephemeral']
                 subparser.add_argument(*args, **kwargs)
 
         # finally, we add the ConfigOption to the internal dict for tracking
@@ -419,7 +420,7 @@ class ReceptorConfig:
                 self._config_options['plugins'][section.replace("plugin_", "")] = dict(self._config_file[section])
         # If we did not get a data_dir from anywhere else, use a default
         if self._config_options['default_data_dir'].value is None:
-            if hasattr(self._parsed_args, 'is_ephemeral') and self._parsed_args.is_ephemeral:
+            if self._is_ephemeral:
                 self._config_options['default_data_dir'].value = '/tmp/receptor'
             else:
                 self._config_options['default_data_dir'].value = '/var/lib/receptor'

--- a/receptor/controller.py
+++ b/receptor/controller.py
@@ -37,8 +37,7 @@ class Controller:
         self.connection_manager.get_peer(peer)
 
     async def recv(self):
-        inner = await self.receptor.response_queue.get()
-        return inner.raw_payload
+        return await self.receptor.response_queue.get()
 
     async def send(self, message, expect_response=True):
         new_id = uuid.uuid4()

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -152,14 +152,27 @@ def run_as_status(config):
     async def status_entrypoint():
         controller.add_peer(config.status_peer)
         start_wait = time.time()
-        while not controller.receptor.router.node_is_known(config.status_peer) and (time.time() - start_wait < 5):
+        r = controller.receptor
+        while not r.router.node_is_known(config.status_peer) and (time.time() - start_wait < 5):
             await asyncio.sleep(0.1)
+
+        # This output should be formatted so as to be parseable as YAML
+
         print("Nodes:")
-        print("  Myself:", controller.receptor.router.node_id)
-        print("  Others:", ", ".join(list(controller.receptor.router.get_nodes())))
-        print("Edges:")
-        for edge in controller.receptor.router.get_edges():
-            print("  ", edge)
+        print("  Myself:", r.router.node_id)
+        print("  Others:")
+        for node in r.router.get_nodes():
+            print("  -", node)
+        print()
+        print("Route Map:")
+        for edge in r.router.get_edges():
+            print("-", str(tuple(edge)))
+        print()
+        print("Known Node Capabilities:")
+        for node, node_caps in r.node_capabilities.items():
+            print("  ", node, ":", sep="")
+            for cap, cap_value in node_caps.items():
+                print("    ", cap, ": ", str(cap_value), sep="")
 
     try:
         controller = Controller(config)

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -3,6 +3,7 @@ import time
 import asyncio
 import sys
 import os
+import shutil
 
 from prometheus_client import start_http_server
 
@@ -10,6 +11,20 @@ from .controller import Controller
 from .messages import Message
 
 logger = logging.getLogger(__name__)
+
+
+def cleanup_tmpdir(controller):
+    try:
+        is_ephemeral = controller.receptor.config._is_ephemeral
+        base_path = controller.receptor.base_path
+    except AttributeError:
+        return
+    if is_ephemeral:
+        try:
+            logger.debug(f"Removing temporary directory {base_path}")
+            shutil.rmtree(base_path)
+        except Exception:
+            logger.error(f"Error while removing temporary directory {base_path}", exc_info=True)
 
 
 def run_as_node(config):
@@ -24,30 +39,36 @@ def run_as_node(config):
                                 controller.loop.create_task,
                                 node_keepalive())
 
-    controller = Controller(config)
-    logger.info(f'Running as Receptor node with ID: {controller.receptor.node_id}')
-    if config.node_stats_enable:
-        logger.info(f'Starting stats on port {config.node_stats_port}')
-        start_http_server(config.node_stats_port)
-    if not config.node_server_disable:
-        controller.enable_server(config.node_listen)
-    for peer in config.node_peers:
-        controller.add_peer(peer)
-    if config.node_keepalive_interval > 1:
-        controller.loop.create_task(node_keepalive())
-    controller.loop.create_task(controller.receptor.watch_expire())
-    controller.run()
+    try:
+        controller = Controller(config)
+        logger.info(f'Running as Receptor node with ID: {controller.receptor.node_id}')
+        if config.node_stats_enable:
+            logger.info(f'Starting stats on port {config.node_stats_port}')
+            start_http_server(config.node_stats_port)
+        if not config.node_server_disable:
+            controller.enable_server(config.node_listen)
+        for peer in config.node_peers:
+            controller.add_peer(peer)
+        if config.node_keepalive_interval > 1:
+            controller.loop.create_task(node_keepalive())
+        controller.loop.create_task(controller.receptor.watch_expire())
+        controller.run()
+    finally:
+        cleanup_tmpdir(controller)
 
 
 def run_as_controller(config):
-    controller = Controller(config)
-    logger.info(f'Running as Receptor controller with ID: {controller.receptor.node_id}')
-    if config.controller_stats_enable:
-        logger.info(f'Starting stats on port {config.node_stats_port}')
-        start_http_server(config.controller_stats_port)
-    controller.enable_server(config.controller_listen)
-    controller.loop.create_task(controller.receptor.watch_expire())
-    controller.run()
+    try:
+        controller = Controller(config)
+        logger.info(f'Running as Receptor controller with ID: {controller.receptor.node_id}')
+        if config.controller_stats_enable:
+            logger.info(f'Starting stats on port {config.node_stats_port}')
+            start_http_server(config.controller_stats_port)
+        controller.enable_server(config.controller_listen)
+        controller.loop.create_task(controller.receptor.watch_expire())
+        controller.run()
+    finally:
+        cleanup_tmpdir()
 
 
 def run_as_ping(config):
@@ -78,9 +99,12 @@ def run_as_ping(config):
             await controller.ping(config.ping_recipient)
             await asyncio.sleep(config.ping_delay)
 
-    logger.info(f'Sending ping to {config.ping_recipient} via {config.ping_peer}.')
-    controller = Controller(config)
-    controller.run(ping_entrypoint)
+    try:
+        logger.info(f'Sending ping to {config.ping_recipient} via {config.ping_peer}.')
+        controller = Controller(config)
+        controller.run(ping_entrypoint)
+    finally:
+        cleanup_tmpdir(controller)
 
 
 def run_as_send(config):
@@ -108,15 +132,19 @@ def run_as_send(config):
         while True:
             message = await controller.recv()
             if message.message_type == 'response':
+                logger.debug(f'Received response messsage')
                 print("{}".format(message.raw_payload))
             elif message.message_type == 'eof':
+                logger.info(f'Received EOF')
                 break
             else:
-                print("Got unknown message type {}".format(message.message_type))
-
-    logger.info(f'Sending directive {config.send_directive} to {config.send_recipient} via {config.send_peer}')
-    controller = Controller(config)
-    controller.run(send_entrypoint)
+                logger.warning("Received unknown message type {}".format(message.message_type))
+    try:
+        logger.info(f'Sending directive {config.send_directive} to {config.send_recipient} via {config.send_peer}')
+        controller = Controller(config)
+        controller.run(send_entrypoint)
+    finally:
+        cleanup_tmpdir(controller)
 
 
 def run_as_status(config):
@@ -133,5 +161,8 @@ def run_as_status(config):
         for edge in controller.receptor.router.get_edges():
             print("  ", edge)
 
-    controller = Controller(config)
-    controller.run(status_entrypoint)
+    try:
+        controller = Controller(config)
+        controller.run(status_entrypoint)
+    finally:
+        cleanup_tmpdir(controller)

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -70,8 +70,8 @@ def run_as_ping(config):
 
     async def read_responses():
         for _ in ping_iter():
-            payload = await controller.recv()
-            print("{}".format(payload))
+            message = await controller.recv()
+            print("{}".format(message.raw_payload))
 
     async def send_pings():
         for _ in ping_iter():
@@ -106,7 +106,13 @@ def run_as_send(config):
 
     async def read_responses():
         while True:
-            print("{}".format(await controller.recv()))
+            message = await controller.recv()
+            if message.message_type == 'response':
+                print("{}".format(message.raw_payload))
+            elif message.message_type == 'eof':
+                break
+            else:
+                print("Got unknown message type {}".format(message.message_type))
 
     logger.info(f'Sending directive {config.send_directive} to {config.send_recipient} via {config.send_peer}')
     controller = Controller(config)

--- a/receptor/messages/envelope.py
+++ b/receptor/messages/envelope.py
@@ -251,7 +251,7 @@ class Inner:
         self.message_id = message_id
         self.sender = sender
         self.recipient = recipient
-        self.message_type = message_type  # 'directive' or 'response'
+        self.message_type = message_type  # 'directive', 'response' or 'eof'
         self.timestamp = timestamp  # ISO format
         self.raw_payload = raw_payload
         self.directive = directive  # None if response, 'namespace:action' if not
@@ -290,6 +290,25 @@ class Inner:
             in_response_to=in_response_to,
             ttl=ttl,
             serial=serial,
+            code=code,
+        )
+
+    @classmethod
+    def make_eof(
+        cls, receptor, recipient, in_response_to, ttl=None, code=0
+    ):
+        return cls(
+            receptor=receptor,
+            message_id=str(uuid.uuid4()),
+            sender=receptor.node_id,
+            recipient=recipient,
+            message_type="eof",
+            timestamp=datetime.datetime.utcnow().isoformat(),
+            raw_payload=None,
+            directive=None,
+            in_response_to=in_response_to,
+            ttl=ttl,
+            serial=None,
             code=code,
         )
 

--- a/receptor/receptor.py
+++ b/receptor/receptor.py
@@ -1,5 +1,4 @@
 import asyncio
-import copy
 import json
 import logging
 import os
@@ -33,6 +32,9 @@ class Receptor:
         self.connection_manifest_path = os.path.join(self.base_path, "connection_manifest")
         self.buffer_mgr = self.config.components_buffer_manager
         self.stop = False
+        self.node_capabilities = {
+                self.node_id: self.work_manager.get_capabilities()
+                }
         try:
             receptor_dist = pkg_resources.get_distribution("receptor")
             receptor_version = receptor_dist.version
@@ -57,27 +59,23 @@ class Receptor:
                 buffer = self.buffer_mgr.get_buffer_for_node(connection["id"], self)
                 await buffer.expire()
                 if connection["last"] + 86400 < time.time():
-                    logger.info("Expiring connection {}".format(connection["id"]))
-                    write_manifest = copy.copy(current_manifest)
-                    write_manifest.remove(connection)
-                    self.write_connection_manifest(write_manifest)
+                    self.remove_connection_manifest(connection["id"])
             await asyncio.sleep(600)
 
     def get_connection_manifest(self):
         if not os.path.exists(self.connection_manifest_path):
             return []
         try:
-            fd = open(self.connection_manifest_path, "r")
-            manifest = json.load(fd)
+            with open(self.connection_manifest_path, "r") as fd:
+                manifest = json.load(fd)
             return manifest
         except Exception as e:
             logger.warn("Failed to read connection manifest: {}".format(e))
             return []
 
     def write_connection_manifest(self, manifest):
-        fd = open(self.connection_manifest_path, "w")
-        json.dump(manifest, fd)
-        fd.close()
+        with open(self.connection_manifest_path, "w") as fd:
+            json.dump(manifest, fd)
 
     def update_connection_manifest(self, connection):
         manifest = self.get_connection_manifest()
@@ -91,6 +89,13 @@ class Receptor:
             manifest.append(dict(id=connection,
                             last=time.time()))
         self.write_connection_manifest(manifest)
+
+    def remove_connection_manifest(self, connection):
+        logger.info("Expiring connection {}".format(connection))
+        manifest = self.get_connection_manifest()
+        if connection in manifest:
+            manifest.remove(connection)
+            self.write_connection_manifest(manifest)
 
     async def message_handler(self, buf):
         logger.debug("spawning message_handler")
@@ -132,10 +137,17 @@ class Receptor:
         for connection_node in self.connections:
             if protocol_obj in self.connections[connection_node]:
                 logger.info("Removing connection {} for node {}".format(protocol_obj, connection_node))
-                self.update_connection_manifest(connection_node)
-                self.connections[connection_node].remove(protocol_obj)
-                self.router.update_node(self.node_id, connection_node, 100)
-                self.update_connection_manifest(connection_node)
+                if (connection_node in self.node_capabilities and
+                        "ephemeral" in self.node_capabilities[connection_node] and
+                        self.node_capabilities[connection_node]["ephemeral"]):
+                    self.connections[connection_node].remove(protocol_obj)
+                    self.router.remove_node(connection_node)
+                    self.remove_connection_manifest(connection_node)
+                    del self.node_capabilities[connection_node]
+                else:
+                    self.connections[connection_node].remove(protocol_obj)
+                    self.router.update_node(self.node_id, connection_node, 100)
+                    self.update_connection_manifest(connection_node)
             notify_connections += self.connections[connection_node]
         loop.create_task(self.send_route_advertisement(self.router.get_edges()))
 
@@ -156,6 +168,7 @@ class Receptor:
         })
 
     async def handle_route_advertisement(self, data):
+        self.node_capabilities[data["id"]] = data["capabilities"]
         self.router.add_edges(data["edges"])
         await self.send_route_advertisement(data["edges"], data["seen"])
 

--- a/receptor/receptor.py
+++ b/receptor/receptor.py
@@ -227,6 +227,7 @@ class Receptor:
         handlers = dict(
             directive=self.handle_directive,
             response=self.handle_response,
+            eof=self.handle_response,
         )
         messages_received_counter.inc()
         next_hop = self.router.next_hop(msg.header["recipient"])

--- a/receptor/work.py
+++ b/receptor/work.py
@@ -30,8 +30,16 @@ class WorkManager:
         return entry_points[0].load()
 
     def get_capabilities(self):
-        return [(x.name, pkg_resources.get_distribution(x.resolve().__package__).version)
-                for x in pkg_resources.iter_entry_points('receptor.worker')]
+        caps = {
+            'worker_versions': {
+                x.name: pkg_resources.get_distribution(x.resolve().__package__).version
+                for x in pkg_resources.iter_entry_points('receptor.worker')
+                },
+            'max_work_threads': self.receptor.config.default_max_workers,
+        }
+        if self.receptor.config._is_ephemeral:
+            caps['ephemeral'] = True
+        return caps
 
     def get_work(self):
         return self.active_work

--- a/receptor/work.py
+++ b/receptor/work.py
@@ -62,9 +62,7 @@ class WorkManager:
                 raise exceptions.InvalidDirectiveAction(f'Invalid action {action} for {namespace}')
             self.add_work(inner_env)
             response_queue = queue.Queue()
-            work_exec = self.thread_pool.submit(action_method, inner_env,
-                self.receptor.config.plugins.get(namespace, {}),
-                response_queue)
+            work_exec = self.thread_pool.submit(action_method, inner_env, self.receptor.config.plugins.get(namespace, {}), response_queue)
             while True:
                 # Collect 'done' status here so we drain the response queue
                 # after the work is complete

--- a/receptor/work.py
+++ b/receptor/work.py
@@ -68,6 +68,10 @@ class WorkManager:
             except AttributeError:
                 logger.exception(f'Could not load action {action} from {namespace}')
                 raise exceptions.InvalidDirectiveAction(f'Invalid action {action} for {namespace}')
+            if not getattr(action_method, "receptor_export", False):
+                logger.exception(f'Not allowed to call {action} from {namespace} because it is not marked for export')
+                raise exceptions.InvalidDirectiveAction(f'Access denied calling {action} for {namespace}')
+
             self.add_work(inner_env)
             response_queue = queue.Queue()
             work_exec = self.thread_pool.submit(action_method, inner_env, self.receptor.config.plugins.get(namespace, {}), response_queue)

--- a/receptor/work.py
+++ b/receptor/work.py
@@ -7,6 +7,10 @@ from . import exceptions
 from .messages import envelope
 from .stats import active_work_gauge, work_counter, work_info
 
+import concurrent.futures
+import queue
+import asyncio
+
 logger = logging.getLogger(__name__)
 
 
@@ -15,6 +19,8 @@ class WorkManager:
         self.receptor = receptor
         work_info.info(dict(plugins=str(self.get_capabilities())))
         self.active_work = []
+        self.thread_pool = concurrent.futures.ThreadPoolExecutor(
+                max_workers=self.receptor.config.default_max_workers)
 
     def load_receptor_worker(self, name):
         entry_points = [x for x in filter(lambda x: x.name == name,
@@ -55,18 +61,39 @@ class WorkManager:
                 logger.exception(f'Could not load action {action} from {namespace}')
                 raise exceptions.InvalidDirectiveAction(f'Invalid action {action} for {namespace}')
             self.add_work(inner_env)
-            responses = action_method(inner_env, self.receptor.config.plugins.get(namespace, {}))
-            async for response in responses:
-                serial += 1
-                logger.debug(f'Response emitted for {inner_env.message_id}, serial {serial}')
-                enveloped_response = envelope.Inner.make_response(
-                    receptor=self.receptor,
-                    recipient=inner_env.sender,
-                    payload=response,
-                    in_response_to=inner_env.message_id,
-                    serial=serial
-                )
-                await self.receptor.router.send(enveloped_response)
+            response_queue = queue.Queue()
+            work_exec = self.thread_pool.submit(action_method, inner_env,
+                self.receptor.config.plugins.get(namespace, {}),
+                response_queue)
+            while True:
+                # Collect 'done' status here so we drain the response queue
+                # after the work is complete
+                is_done = work_exec.done()
+                while True:
+                    try:
+                        response = response_queue.get(False)
+                        serial += 1
+                        logger.debug(f'Response emitted for {inner_env.message_id}, serial {serial}')
+                        enveloped_response = envelope.Inner.make_response(
+                            receptor=self.receptor,
+                            recipient=inner_env.sender,
+                            payload=response,
+                            in_response_to=inner_env.message_id,
+                            serial=serial
+                        )
+                        await self.receptor.router.send(enveloped_response)
+                    except queue.Empty:
+                        break
+                if is_done:
+                    break
+                await asyncio.sleep(0)
+            eof_response = envelope.Inner.make_eof(
+                receptor=self.receptor,
+                recipient=inner_env.sender,
+                in_response_to=inner_env.message_id,
+            )
+            await self.receptor.router.send(eof_response)
+
         except Exception as e:
             serial += 1
             logger.error(f'Error encountered while handling the response, replying with an error message ({e})')


### PR DESCRIPTION
- Change plugin worker interface to use a thread pool and thread-safe queue
  	- This isolates plugins from the asyncio event loop, and makes them simpler.
	- This breaks all existing plugins.
- Change recv() to return the whole message, not just the raw_payload
	- This also breaks all existing plugins.
- Add an EOF message type that indicates all response data has been sent
- Create a category of 'ephemeral' commands that will exit when EOF is received
- Use /tmp/receptor instead of /var/lib/receptor for ephemeral commands
- Connect to localhost:8888 by default for ping, status and send
- Change default ping behavior to count of 4 with 1-second intervals
