### PR TITLE
Add optional additional payloads to pings.

### DIFF
--- a/receptor/controller.py
+++ b/receptor/controller.py
@@ -55,8 +55,8 @@ class Controller:
         await self.receptor.router.send(inner_env, expected_response=expect_response)
         return new_id
 
-    async def ping(self, destination, expected_response=True):
-        return await self.receptor.router.ping_node(destination, expected_response)
+    async def ping(self, destination, flags=0b0, expected_response=True):
+        return await self.receptor.router.ping_node(destination, flags, expected_response)
 
     def run(self, app=None):
         try:

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -75,7 +75,7 @@ def run_as_ping(config):
 
     async def send_pings():
         for _ in ping_iter():
-            await controller.ping(config.ping_recipient)
+            await controller.ping(config.ping_recipient, config.ping_flags or 0)
             await asyncio.sleep(config.ping_delay)
 
     logger.info(f'Sending ping to {config.ping_recipient} via {config.ping_peer}.')

--- a/receptor/receptor.py
+++ b/receptor/receptor.py
@@ -35,10 +35,10 @@ class Receptor:
         self.stop = False
         try:
             receptor_dist = pkg_resources.get_distribution("receptor")
-            receptor_version = receptor_dist.version
+            self.receptor_version = receptor_dist.version
         except pkg_resources.DistributionNotFound:
-            receptor_version = 'unknown'
-        receptor_info.info(dict(node_id=self.node_id, receptor_version=receptor_version))
+            self.receptor_version = 'unknown'
+        receptor_info.info(dict(node_id=self.node_id, receptor_version=self.receptor_version))
 
     def _find_node_id(self):
         if 'RECEPTOR_NODE_ID' in os.environ:

--- a/receptor/router.py
+++ b/receptor/router.py
@@ -1,5 +1,6 @@
 import datetime
 import heapq
+import json
 import logging
 import random
 import uuid
@@ -73,7 +74,7 @@ class MeshRouter:
     def get_nodes(self):
         return self._nodes
 
-    async def ping_node(self, node_id, expected_response=True):
+    async def ping_node(self, node_id, flags=0, expected_response=True):
         logger.info(f'Sending ping to node {node_id}')
         now = datetime.datetime.utcnow().isoformat()
         ping_envelope = envelope.Inner(
@@ -83,7 +84,7 @@ class MeshRouter:
             recipient=node_id,
             message_type='directive',
             timestamp=now,
-            raw_payload=now,
+            raw_payload=json.dumps(dict(ts=now, flags=flags)),
             directive='receptor:ping',
             ttl=15
         )


### PR DESCRIPTION
Adds optional command line flags `--with-work`, `--with-peering`, `--with-capabilities`, and `--with-status` which sets flags on a ping request to augment responses with information about the remote node's running status.

Definitely wanting some feedback on the options for node status and the content of the responses.