### PR TITLE
Use EOF code field to indicate abnormal termination

### DIFF
--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -132,13 +132,16 @@ def run_as_send(config):
         while True:
             message = await controller.recv()
             if message.message_type == 'response':
-                logger.debug(f'Received response messsage')
-                print("{}".format(message.raw_payload))
+                logger.debug('Received response message')
+                print(f'{message.raw_payload}')
             elif message.message_type == 'eof':
-                logger.info(f'Received EOF')
+                logger.info('Received EOF')
+                if message.code != 0:
+                    logger.error(f'EOF was an error result: {message.raw_payload}')
+                    print(f'ERROR: {message.raw_payload}')
                 break
             else:
-                logger.warning("Received unknown message type {}".format(message.message_type))
+                logger.warning(f'Received unknown message type {message.message_type}')
     try:
         logger.info(f'Sending directive {config.send_directive} to {config.send_recipient} via {config.send_peer}')
         controller = Controller(config)

--- a/receptor/messages/envelope.py
+++ b/receptor/messages/envelope.py
@@ -272,7 +272,8 @@ class Inner:
 
     @classmethod
     def make_response(
-        cls, receptor, recipient, payload, in_response_to, serial, ttl=None, code=0
+        cls, receptor, recipient, payload, in_response_to, serial, ttl=None,
+        code=0, message_type="response"
     ):
         if isinstance(payload, bytes):
             encoded_payload = base64.encodebytes(payload)
@@ -283,32 +284,13 @@ class Inner:
             message_id=str(uuid.uuid4()),
             sender=receptor.node_id,
             recipient=recipient,
-            message_type="response",
+            message_type=message_type,
             timestamp=datetime.datetime.utcnow().isoformat(),
             raw_payload=encoded_payload,
             directive=None,
             in_response_to=in_response_to,
             ttl=ttl,
             serial=serial,
-            code=code,
-        )
-
-    @classmethod
-    def make_eof(
-        cls, receptor, recipient, in_response_to, ttl=None, code=0
-    ):
-        return cls(
-            receptor=receptor,
-            message_id=str(uuid.uuid4()),
-            sender=receptor.node_id,
-            recipient=recipient,
-            message_type="eof",
-            timestamp=datetime.datetime.utcnow().isoformat(),
-            raw_payload=None,
-            directive=None,
-            in_response_to=in_response_to,
-            ttl=ttl,
-            serial=None,
             code=code,
         )
 


### PR DESCRIPTION
Currently, when a worker experiences an exception, we send a normal `response` message with the payload set to the text of the exception error message.  This presents a problem for controllers: when they receive a response, they don't know if they should parse the payload as their own data format, or as a string containing an error message.

To solve this, this PR moves the error handling to the EOF message.  The `code` field is used to indicate whether an error occurred (0=success).  If an exception occurrs, the payload of the EOF message contains the error text.