### PR TITLE
Improve error handling at connection close

### DIFF
--- a/receptor/work.py
+++ b/receptor/work.py
@@ -124,3 +124,5 @@ class WorkManager:
                 message_type="eof",
             )
         await self.receptor.router.send(eof_response)
+        if self.receptor.is_ephemeral(inner_env.sender):
+            self.receptor.remove_connection_by_id(inner_env.sender)


### PR DESCRIPTION
This PR does two things related to connection shutdown:

- Immediately removes ephemeral nodes rather than letting them hang around until the next broadcast or route advertisement
- Stops emitting so many tracebacks (and tracebacks within tracebacks) whenever a connection is closed