### PR TITLE
pulling in a logstash formatter for structured log output

### DIFF
--- a/receptor/__main__.py
+++ b/receptor/__main__.py
@@ -5,6 +5,7 @@ import signal
 import sys
 
 from .config import ReceptorConfig
+from .logstash_formatter.logstash import LogstashFormatter
 
 logger = logging.getLogger(__name__)
 
@@ -22,15 +23,18 @@ def main(args=None):
             'version': 1,
             'disable_existing_loggers': False,
             'formatters': {
-                'verbose': {
+                'simple': {
                     'format': '{levelname} {asctime} {node_id} {module} {message}',
                     'style': '{',
-                }
+                },
+                'structured': {
+                    '()': LogstashFormatter,
+                },
             },
             'handlers': {
                 'console': {
                     'class': 'logging.StreamHandler',
-                    'formatter': 'verbose'
+                    'formatter': 'structured' if config.default_logging_format == 'structured' else 'simple'
                 },
             },
             'loggers': {

--- a/receptor/config.py
+++ b/receptor/config.py
@@ -99,7 +99,14 @@ class ReceptorConfig:
             default_value=default_max_workers,
             value_type='int',
             hint='Size of the thread pool for worker threads. If unspecified, defaults to {}'.format(default_max_workers),
-        ),
+        )
+        self.add_config_option(
+            section='default',
+            key='logging_format',
+            default_value='simple',
+            value_type='str',
+            hint='Format of logging output.  Options are "simple" and "structured", default is "simple"',
+        )
         # Auth section options. This is a new section for the config file only,
         # so all of these options use `subparse=False`.
         self.add_config_option(

--- a/receptor/logstash_formatter/LICENSE
+++ b/receptor/logstash_formatter/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2012 Exoscale SA
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/receptor/logstash_formatter/logstash.py
+++ b/receptor/logstash_formatter/logstash.py
@@ -1,0 +1,128 @@
+"""
+This module was taken in part from:
+https://github.com/ulule/python-logstash-formatter
+"""
+import datetime
+import json
+import logging
+import socket
+import traceback as tb
+
+
+def _default_json_default(obj):
+    """
+    Coerce everything to strings.
+    All objects representing time get output as ISO8601.
+    """
+    if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
+        return obj.isoformat()
+    else:
+        return str(obj)
+
+
+class LogstashFormatter(logging.Formatter):
+    """
+    A custom formatter to prepare logs to be
+    shipped out to logstash.
+    """
+
+    def __init__(self,
+                 fmt=None,
+                 datefmt=None,
+                 style='%',
+                 json_cls=None,
+                 json_default=_default_json_default):
+        """
+        :param fmt: Config as a JSON string, allowed fields;
+               extra: provide extra fields always present in logs
+               source_host: override source host name
+        :param datefmt: Date format to use (required by logging.Formatter
+            interface but not used)
+        :param json_cls: JSON encoder to forward to json.dumps
+        :param json_default: Default JSON representation for unknown types,
+                             by default coerce everything to a string
+        """
+
+        if fmt is not None:
+            self._fmt = json.loads(fmt)
+        else:
+            self._fmt = {}
+        self.json_default = json_default
+        self.json_cls = json_cls
+        if 'extra' not in self._fmt:
+            self.defaults = {}
+        else:
+            self.defaults = self._fmt['extra']
+        if 'source_host' in self._fmt:
+            self.source_host = self._fmt['source_host']
+        else:
+            try:
+                self.source_host = socket.gethostname()
+            except Exception:
+                self.source_host = ""
+
+    def format(self, record):
+        """
+        Format a log record to JSON, if the message is a dict
+        assume an empty message and use the dict as additional
+        fields.
+        """
+
+        fields = record.__dict__.copy()
+
+        if isinstance(record.msg, dict):
+            fields.update(record.msg)
+            fields.pop('msg')
+            msg = ""
+        else:
+            msg = record.getMessage()
+
+        try:
+            msg = msg.format(**fields)
+        except (KeyError, IndexError, ValueError):
+            pass
+        except Exception:
+            # in case we can not format the msg properly we log it as is instead of crashing
+            msg = msg
+
+        if 'msg' in fields:
+            fields.pop('msg')
+
+        if 'exc_info' in fields:
+            if fields['exc_info']:
+                formatted = tb.format_exception(*fields['exc_info'])
+                fields['exception'] = formatted
+            fields.pop('exc_info')
+
+        if 'exc_text' in fields and not fields['exc_text']:
+            fields.pop('exc_text')
+
+        logr = self.defaults.copy()
+
+        # remove nulls
+        fields = {k: v for k, v in fields.items() if v}
+
+        logr.update({'@message': msg,
+                     '@timestamp': datetime.datetime.utcnow().isoformat(),
+                     '@source_host': self.source_host,
+                     '@fields': self._build_fields(logr, fields)})
+
+        return json.dumps(logr, default=self.json_default, cls=self.json_cls)
+
+    def _build_fields(self, defaults, fields):
+        """Return provided fields including any in defaults
+        >>> f = LogstashFormatter()
+        # Verify that ``fields`` is used
+        >>> f._build_fields({}, {'foo': 'one'}) == \
+                {'foo': 'one'}
+        True
+        # Verify that ``@fields`` in ``defaults`` is used
+        >>> f._build_fields({'@fields': {'bar': 'two'}}, {'foo': 'one'}) == \
+                {'foo': 'one', 'bar': 'two'}
+        True
+        # Verify that ``fields`` takes precedence
+        >>> f._build_fields({'@fields': {'foo': 'two'}}, {'foo': 'one'}) == \
+                {'foo': 'one'}
+        True
+        """
+        return dict(list(defaults.get('@fields', {}).items()) + list(fields.items()))


### PR DESCRIPTION
The rationale is to add structured logging output so that users can integrate the logging into aggregation systems more easily.  This also allows more context to be added to logs for later automation.

Todo for this PR is more robust configuration for logging in __main__.

Signed-off-by: Jesse Jaggars <jjaggars@redhat.com>