### PR TITLE
Connection-level TLS/SSL

### DIFF
--- a/receptor/config.py
+++ b/receptor/config.py
@@ -155,6 +155,22 @@ class ReceptorConfig:
             subparse=False,
             hint='Path to the CA bundle used by servers to verify clients.',
         )
+        self.add_config_option(
+            section='auth',
+            key='server_cipher_list',
+            default_value=None,
+            value_type='str',
+            subparse=False,
+            hint='TLS cipher list for use by the server.',
+        )
+        self.add_config_option(
+            section='auth',
+            key='client_cipher_list',
+            default_value=None,
+            value_type='str',
+            subparse=False,
+            hint='TLS cipher list for use by the client.',
+        )
         # Receptor node options
         self.add_config_option(
             section='node',
@@ -521,6 +537,9 @@ class ReceptorConfig:
         ca_bundle = self.auth_server_ca_bundle
         ca_bundle = ca_bundle if ca_bundle else None   # Make false-like values like '' explicitly None
         sc = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        sc.options |= ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_TLSv1_2
+        if self.auth_client_cipher_list:
+            sc.set_ciphers(self.auth_client_cipher_list)
         sc.verify_mode = ssl.CERT_REQUIRED
         if self.auth_server_ca_bundle:
             sc.load_verify_locations(self.auth_server_ca_bundle)
@@ -535,6 +554,9 @@ class ReceptorConfig:
         ca_bundle = self.auth_client_verification_ca
         ca_bundle = ca_bundle if ca_bundle else None   # Make false-like values like '' explicitly None
         sc = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        sc.options |= ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_TLSv1_2
+        if self.auth_server_cipher_list:
+            sc.set_ciphers(self.auth_server_cipher_list)
         if self.auth_client_verification_ca:
             sc.load_verify_locations(self.auth_client_verification_ca)
             sc.verify_mode = ssl.CERT_REQUIRED

--- a/receptor/connection/base.py
+++ b/receptor/connection/base.py
@@ -8,6 +8,16 @@ from ..messages.envelope import FramedBuffer
 logger = logging.getLogger(__name__)
 
 
+def log_ssl_detail(transport):
+    peername = transport.get_extra_info('peername')
+    if transport.get_extra_info('ssl_object', None):
+        cipher = transport.get_extra_info('cipher')
+        peercert = transport.get_extra_info('peercert')
+        logger.debug(f"{cipher[1]} connection with {str(peername)} using cipher {cipher[0]} and certificate {str(peercert)}.")
+    else:
+        logger.debug(f"Unencrypted connection with {str(peername)}.")
+
+
 class Transport(AsyncIterator):
     @abstractmethod
     async def close(self):

--- a/receptor/connection/manager.py
+++ b/receptor/connection/manager.py
@@ -7,36 +7,42 @@ from . import sock, ws
 
 def parse_peer(peer):
     if "://" not in peer:
-        peer = f"receptor://{peer}"
+        peer = f"rnp://{peer}"
+    if peer.startswith("receptor://"):
+        peer = peer.replace("receptor", "rnp", 1)
     return urlparse(peer)
 
 
 class Manager:
-    def __init__(self, factory, ssl_context, loop=None):
+    def __init__(self, factory, ssl_context_factory, loop=None):
         self.factory = factory
-        self.ssl_context = ssl_context
+        self.ssl_context_factory = ssl_context_factory
         self.loop = loop or asyncio.get_event_loop()
 
     def get_listener(self, listen_url):
         service = parse_peer(listen_url)
-        if service.scheme == "receptor":
+        ssl_context = None if service.scheme in ("rnp", "ws") else self.ssl_context_factory('server')
+        if service.scheme in ("rnp", "rnps"):
             return asyncio.start_server(
                 functools.partial(sock.serve, factory=self.factory),
                 host=service.hostname,
                 port=service.port,
-                ssl=self.ssl_context,
+                ssl=ssl_context,
             )
         elif service.scheme in ("ws", "wss"):
             return self.loop.create_server(
                 ws.app(self.factory).make_handler(),
                 service.hostname,
                 service.port,
-                ssl=self.ssl_context,
+                ssl=ssl_context,
             )
 
-    def get_peer(self, peer):
+    def get_peer(self, peer, reconnect=True):
         service = parse_peer(peer)
-        if service.scheme == "receptor":
-            self.loop.create_task(sock.connect(service.hostname, service.port, self.factory, self.loop, self.ssl_context))
+        ssl_context = None if service.scheme in ("rnp", "ws") else self.ssl_context_factory('client')
+        if service.scheme in ("rnp", "rnps"):
+            return self.loop.create_task(sock.connect(service.hostname, service.port, self.factory,
+                                         self.loop, ssl_context, reconnect))
         elif service.scheme in ("ws", "wss"):
-            self.loop.create_task(ws.connect(peer, self.factory, self.loop, self.ssl_context))
+            return self.loop.create_task(ws.connect(peer, self.factory, self.loop,
+                                         ssl_context, reconnect))

--- a/receptor/connection/sock.py
+++ b/receptor/connection/sock.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from .base import Transport
+from .base import Transport, log_ssl_detail
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,7 @@ async def connect(host, port, factory, loop=None, ssl=None, reconnect=True):
     worker = factory()
     try:
         r, w = await asyncio.open_connection(host, port, loop=loop, ssl=ssl)
+        log_ssl_detail(w._transport)
         t = RawSocket(r, w)
         await worker.client(t)
     except Exception:
@@ -53,5 +54,6 @@ async def connect(host, port, factory, loop=None, ssl=None, reconnect=True):
 
 
 async def serve(reader, writer, factory):
+    log_ssl_detail(writer._transport)
     t = RawSocket(reader, writer)
     await factory().server(t)

--- a/receptor/connection/ws.py
+++ b/receptor/connection/ws.py
@@ -51,7 +51,7 @@ async def connect(uri, factory, loop=None, ssl_context=None, reconnect=True):
 
 async def serve(request, factory):
     ws = aiohttp.web.WebSocketResponse()
-    log_ssl_detail(ws)
+    log_ssl_detail(request.transport)
     await ws.prepare(request)
 
     t = WebSocket(ws)

--- a/receptor/connection/ws.py
+++ b/receptor/connection/ws.py
@@ -4,7 +4,7 @@ import aiohttp
 import aiohttp.web
 import asyncio
 
-from .base import Transport
+from .base import Transport, log_ssl_detail
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +35,7 @@ async def connect(uri, factory, loop=None, ssl_context=None, reconnect=True):
     worker = factory()
     try:
         async with aiohttp.ClientSession().ws_connect(uri, ssl=ssl_context) as ws:
+            log_ssl_detail(ws)
             t = WebSocket(ws)
             await worker.client(t)
     except Exception:
@@ -50,6 +51,7 @@ async def connect(uri, factory, loop=None, ssl_context=None, reconnect=True):
 
 async def serve(request, factory):
     ws = aiohttp.web.WebSocketResponse()
+    log_ssl_detail(ws)
     await ws.prepare(request)
 
     t = WebSocket(ws)

--- a/receptor/connection/ws.py
+++ b/receptor/connection/ws.py
@@ -28,7 +28,7 @@ class WebSocket(Transport):
         await self.ws.send_bytes(bytes_)
 
 
-async def connect(uri, factory, loop=None, ssl_context=None):
+async def connect(uri, factory, loop=None, ssl_context=None, reconnect=True):
     if not loop:
         loop = asyncio.get_event_loop()
 
@@ -39,10 +39,13 @@ async def connect(uri, factory, loop=None, ssl_context=None):
             await worker.client(t)
     except Exception:
         logger.exception("ws.connect")
+        return False
     finally:
-        await asyncio.sleep(5)
-        logger.debug("ws.connect: reconnecting")
-        loop.create_task(connect(uri, factory=factory, loop=loop, ssl_context=ssl_context))
+        if reconnect:
+            await asyncio.sleep(5)
+            logger.debug("ws.connect: reconnecting")
+            loop.create_task(connect(uri, factory=factory, loop=loop, ssl_context=ssl_context))
+        return True
 
 
 async def serve(request, factory):

--- a/receptor/controller.py
+++ b/receptor/controller.py
@@ -18,7 +18,7 @@ class Controller:
         self.loop = loop
         self.connection_manager = Manager(
             lambda: Worker(self.receptor, loop),
-            self.receptor.config.get_server_ssl_context(),
+            self.receptor.config.get_ssl_context,
             loop
         )
         self.queue = queue
@@ -34,7 +34,7 @@ class Controller:
 
     def add_peer(self, peer):
         logger.info("Connecting to peer {}".format(peer))
-        self.connection_manager.get_peer(peer)
+        return self.connection_manager.get_peer(peer, reconnect=not self.receptor.config._is_ephemeral)
 
     async def recv(self):
         return await self.receptor.response_queue.get()


### PR DESCRIPTION
This PR gets SSL working again.  Currently it supports the basic parameters needed to work at all (server cert/key and CA).  Client certificate support is planned, as well as customizations like setting the cipher suite and maybe certificate pinning.  Comments welcome.

Note that the canonical protocol in URI strings is changed from `receptor://` to `rnp://` and `rnps://` ("receptor native protocol").  Backwards compatibility is maintained.