### PR TITLE
Improve error handling when listener fails to bind and on invalid protocol

### DIFF
--- a/receptor/__main__.py
+++ b/receptor/__main__.py
@@ -57,6 +57,8 @@ def main(args=None):
 
     try:
         config.go()
+    except asyncio.CancelledError:
+        pass
     except Exception:
         logger.exception("main: an error occured while running receptor")
         sys.exit(1)

--- a/receptor/connection/manager.py
+++ b/receptor/connection/manager.py
@@ -20,20 +20,28 @@ class Manager:
         self.loop = loop or asyncio.get_event_loop()
 
     def get_listener(self, listen_url):
+
+        default_port = {
+            "rnp": 8888,
+            "rnps": 8899,
+            "ws": 80,
+            "wss": 443,
+        }
+
         service = parse_peer(listen_url)
         ssl_context = self.ssl_context_factory("server") if service.scheme in ("rnps", "wss") else None
         if service.scheme in ("rnp", "rnps"):
             return asyncio.start_server(
                 functools.partial(sock.serve, factory=self.factory),
                 host=service.hostname,
-                port=service.port,
+                port=service.port or default_port[service.scheme],
                 ssl=ssl_context,
             )
         elif service.scheme in ("ws", "wss"):
             return self.loop.create_server(
                 ws.app(self.factory).make_handler(),
                 service.hostname,
-                service.port,
+                service.port or default_port[service.scheme],
                 ssl=ssl_context,
             )
         else:

--- a/receptor/connection/manager.py
+++ b/receptor/connection/manager.py
@@ -21,7 +21,7 @@ class Manager:
 
     def get_listener(self, listen_url):
         service = parse_peer(listen_url)
-        ssl_context = None if service.scheme in ("rnp", "ws") else self.ssl_context_factory('server')
+        ssl_context = self.ssl_context_factory("server") if service.scheme in ("rnps", "wss") else None
         if service.scheme in ("rnp", "rnps"):
             return asyncio.start_server(
                 functools.partial(sock.serve, factory=self.factory),
@@ -36,13 +36,17 @@ class Manager:
                 service.port,
                 ssl=ssl_context,
             )
+        else:
+            raise RuntimeError(f"Unknown URL scheme {service.scheme}")
 
     def get_peer(self, peer, reconnect=True):
         service = parse_peer(peer)
-        ssl_context = None if service.scheme in ("rnp", "ws") else self.ssl_context_factory('client')
+        ssl_context = self.ssl_context_factory("client") if service.scheme in ("rnps", "wss") else None
         if service.scheme in ("rnp", "rnps"):
             return self.loop.create_task(sock.connect(service.hostname, service.port, self.factory,
                                          self.loop, ssl_context, reconnect))
         elif service.scheme in ("ws", "wss"):
             return self.loop.create_task(ws.connect(peer, self.factory, self.loop,
                                          ssl_context, reconnect))
+        else:
+            raise RuntimeError(f"Unknown URL scheme {service.scheme}")

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -46,7 +46,8 @@ def run_as_node(config):
             logger.info(f'Starting stats on port {config.node_stats_port}')
             start_http_server(config.node_stats_port)
         if not config.node_server_disable:
-            controller.enable_server(config.node_listen)
+            listen_tasks = controller.enable_server(config.node_listen)
+            controller.loop.create_task(controller.exit_on_exceptions_in(listen_tasks))
         for peer in config.node_peers:
             controller.add_peer(peer)
         if config.node_keepalive_interval > 1:


### PR DESCRIPTION
* When two receptor nodes attempt to bind to the same port, the second one should error out and exit.
* If you pass an invalid scheme like `receptor node --listen thugbrecht://0.0.0.0:1234` it should error out and exit.  Currently it passes around a None value and eventually emits an obtuse and unhelpful error much later.

See issue #93 