### PR TITLE
Routing improvements

### DIFF
--- a/receptor/controller.py
+++ b/receptor/controller.py
@@ -37,7 +37,7 @@ class Controller:
             task.cancel()
             with suppress(Exception):
                 await task
-        asyncio.gather(*tasks)
+        await asyncio.gather(*tasks)
         self.loop.stop()
 
     async def exit_on_exceptions_in(self, tasks):

--- a/receptor/receptor.py
+++ b/receptor/receptor.py
@@ -119,7 +119,7 @@ class Receptor:
         if id_ is None:
             id_ = protocol_obj.id
 
-        self.router.register_edge(id_, self.node_id, 1)
+        self.router.add_or_update_edges([(id_, self.node_id, 1)])
         if id_ in self.connections:
             self.connections[id_].append(protocol_obj)
         else:
@@ -141,7 +141,7 @@ class Receptor:
                     del self.node_capabilities[connection_node]
                 else:
                     self.connections[connection_node].remove(protocol_obj)
-                    self.router.update_node(self.node_id, connection_node, 100)
+                    self.router.add_or_update_edges([(self.node_id, connection_node, 100)])
                     self.update_connection_manifest(connection_node)
             notify_connections += self.connections[connection_node]
         if loop is None:
@@ -177,7 +177,7 @@ class Receptor:
 
     async def handle_route_advertisement(self, data):
         self.node_capabilities[data["id"]] = data["capabilities"]
-        self.router.add_edges(data["edges"])
+        self.router.add_or_update_edges(data["edges"])
         await self.send_route_advertisement(data["edges"], data["seen"])
 
     async def send_route_advertisement(self, edges=None, seen=[]):

--- a/receptor/receptor.py
+++ b/receptor/receptor.py
@@ -17,6 +17,26 @@ RECEPTOR_DIRECTIVE_NAMESPACE = 'receptor'
 logger = logging.getLogger(__name__)
 
 
+def is_peer_of(edge, node):
+    """If the edge includes the given node, return the other node. Otherwise, return None."""
+    if edge[0] == node:
+        return edge[1]
+    elif edge[1] == node:
+        return edge[0]
+    else:
+        return None
+
+
+def get_peers_of(edges, node):
+    """Gets the peers of a given node"""
+    peers = set()
+    for edge in edges:
+        peer = is_peer_of(edge, node)
+        if peer:
+            peers.add(peer)
+    return peers
+
+
 class Receptor:
     def __init__(self, config, node_id=None, router_cls=None,
                  work_manager_cls=None, response_queue=None):
@@ -129,6 +149,14 @@ class Receptor:
     def add_connection(self, protocol_obj):
         self.update_connections(protocol_obj)
 
+    def remove_ephemeral(self, node):
+        logger.debug(f"Removing ephemeral node {node}")
+        if node in self.connections:
+            self.remove_connection_manifest(node)
+        if node in self.node_capabilities:
+            del self.node_capabilities[node]
+        self.router.remove_node(node)
+
     def remove_connection(self, protocol_obj, id_=None, loop=None):
         notify_connections = []
         for connection_node in self.connections:
@@ -136,9 +164,7 @@ class Receptor:
                 logger.info("Removing connection {} for node {}".format(protocol_obj, connection_node))
                 if self.is_ephemeral(connection_node):
                     self.connections[connection_node].remove(protocol_obj)
-                    self.router.remove_node(connection_node)
-                    self.remove_connection_manifest(connection_node)
-                    del self.node_capabilities[connection_node]
+                    self.remove_ephemeral(connection_node)
                 else:
                     self.connections[connection_node].remove(protocol_obj)
                     self.router.add_or_update_edges([(self.node_id, connection_node, 100)])
@@ -177,12 +203,31 @@ class Receptor:
 
     async def handle_route_advertisement(self, data):
         self.node_capabilities[data["id"]] = data["capabilities"]
-        self.router.add_or_update_edges(data["edges"])
-        await self.send_route_advertisement(data["edges"], data["seen"])
+        if "node_capabilities" in data:
+            for node, caps in data["node_capabilities"].items():
+                self.node_capabilities[node] = caps
+        old_node_peers = get_peers_of(self.router.get_edges(), data["id"])
+        new_node_peers = get_peers_of(data["edges"], data["id"])
+        removed_peers = old_node_peers - new_node_peers
+        for removed_peer in removed_peers:
+            if self.is_ephemeral(removed_peer):
+                self.remove_ephemeral(removed_peer)
+        accepted_edges = list()
+        for edge in data["edges"]:
+            peer = is_peer_of(edge, self.node_id)
+            if peer:
+                if peer == data["id"]:
+                    accepted_edges.append(edge)
+                else:
+                    logger.debug(f"Excluding edge {edge}")
+            else:
+                accepted_edges.append(edge)
+        self.router.add_or_update_edges(accepted_edges)
+        await self.send_route_advertisement(self.router.get_edges(), data["seen"])
 
-    async def send_route_advertisement(self, edges=None, seen=[]):
+    async def send_route_advertisement(self, edges=None, seen=None):
         edges = edges or self.router.get_edges()
-        seen = set(seen)
+        seen = set(seen) if seen else set()
         logger.debug("Emitting Route Advertisements, excluding {}".format(seen))
         destinations = set(self.connections) - seen
         seens = list(seen | destinations | {self.node_id})
@@ -195,6 +240,7 @@ class Receptor:
                     "cmd": "ROUTE",
                     "id": self.node_id,
                     "capabilities": self.work_manager.get_capabilities(),
+                    "node_capabilities": self.node_capabilities,
                     "groups": self.config.node_groups,
                     "edges": edges,
                     "seen": seens
@@ -251,8 +297,9 @@ class Receptor:
             eof=self.handle_response,
         )
         messages_received_counter.inc()
-        next_hop = self.router.next_hop(msg.header["recipient"])
-        if next_hop:
+
+        if msg.header["recipient"] != self.node_id:
+            next_hop = self.router.next_hop(msg.header["recipient"])
             return await self.router.forward(msg, next_hop)
 
         inner = await envelope.Inner.deserialize(self, msg.payload)

--- a/receptor/router.py
+++ b/receptor/router.py
@@ -76,7 +76,7 @@ class MeshRouter:
     def add_or_update_edges(self, edges):
         """
         Adds a list of edges supplied as (node1, node2, cost) tuples.
-        Already-existing edges have their cost set to the lesser of the existing or new cost.
+        Already-existing edges have their cost updated.
         Supplying a cost of None removes the edge.
         """
         for left, right, cost in edges:
@@ -90,7 +90,7 @@ class MeshRouter:
                 self._edges[edge_key] = cost
             elif cost is None:
                 del self._edges[edge_key]
-            elif cost < self._edges[edge_key]:
+            else:
                 self._edges[edge_key] = cost
         self.update_routing_table()
         route_info.info(dict(edges=str(self.get_edges())))
@@ -105,7 +105,9 @@ class MeshRouter:
                 if node in self._neighbors[neighbor]:
                     self._neighbors[neighbor].remove(node)
             del self._neighbors[node]
-        self._nodes.remove(node)
+        if node in self._nodes:
+            self._nodes.remove(node)
+        route_info.info(dict(edges=str(self.get_edges())))
 
     def get_edges(self):
         """Returns set of edges as a list of (node1, node2, cost) tuples."""

--- a/receptor/router.py
+++ b/receptor/router.py
@@ -166,7 +166,9 @@ class MeshRouter:
         given recipient. If the current node is the recipient or there is
         no path, then return None.
         """
-        if recipient in self.routing_table:
+        if recipient == self.node_id:
+            return self.node_id
+        elif recipient in self.routing_table:
             return self.routing_table[recipient][0]
         else:
             return None
@@ -222,4 +224,7 @@ class MeshRouter:
         logger.debug(f'Sending {inner_envelope.message_id} to {inner_envelope.recipient} via {next_node_id}')
         if expected_response and inner_envelope.message_type == 'directive':
             self.response_registry[inner_envelope.message_id] = dict(message_sent_time=inner_envelope.timestamp)
-        await self.forward(msg, next_node_id)
+        if next_node_id == self.node_id:
+            await self.receptor.handle_message(msg)
+        else:
+            await self.forward(msg, next_node_id)

--- a/receptor/router.py
+++ b/receptor/router.py
@@ -1,8 +1,9 @@
+import sys
 import datetime
 import heapq
 import logging
-import random
 import uuid
+import itertools
 from collections import defaultdict
 
 from .exceptions import ReceptorBufferError, UnrouteableError
@@ -12,66 +13,161 @@ from .stats import route_counter, route_info
 logger = logging.getLogger(__name__)
 
 
-class MeshRouter:
-    _nodes = set()
-    _edges = set()
-    response_registry = dict()
+class PriorityQueue:
 
-    def __init__(self, receptor):
+    REMOVED = '$$$%%%<removed-task>%%%$$$'
+
+    def __init__(self):
+        self.heap = list()
+        self.entry_finder = dict()
+        self.counter = itertools.count()
+
+    def add_with_priority(self, item, priority):
+        """Adds an item to the queue, or changes the priority of an existing item."""
+        if item in self.entry_finder:
+            self.remove_item(item)
+        count = next(self.counter)
+        entry = [priority, count, item]
+        self.entry_finder[item] = entry
+        heapq.heappush(self.heap, entry)
+
+    def remove_item(self, item):
+        """Removes an item from the queue."""
+        entry = self.entry_finder.pop(item)
+        entry[-1] = self.REMOVED
+
+    def pop_item(self):
+        """Returns the item from the queue with the lowest sort order."""
+        while self.heap:
+            priority, count, item = heapq.heappop(self.heap)
+            if item is not self.REMOVED:
+                del self.entry_finder[item]
+                return item
+        raise KeyError('Pop from empty PriorityQueue')
+
+    def is_empty(self):
+        """Returns True if the queue is empty."""
+        for entry in self.heap:
+            if entry[-1] is not self.REMOVED:
+                return False
+        return True
+
+
+class MeshRouter:
+
+    def __init__(self, receptor=None, node_id=None):
+        self._nodes = set()
+        self._edges = dict()
+        self._neighbors = defaultdict(set)
+        self.response_registry = dict()
         self.receptor = receptor
-        self.node_id = receptor.node_id
+        if node_id:
+            self.node_id = node_id
+        elif receptor:
+            self.node_id = receptor.node_id
+        else:
+            raise RuntimeError('Unknown node_id')
+        self.routing_table = dict()
         route_info.info(dict(edges="()"))
 
     def node_is_known(self, node_id):
         return node_id in self._nodes or node_id == self.node_id
 
-    def find_edge(self, left, right):
-        node_actual = sorted([left, right])
-        for edge in self._edges:
-            if node_actual[0] == edge[0] and node_actual[1] == edge[1]:
-                return edge
-        return None
-
-    def add_edges(self, edges):
-        for edge in edges:
-            existing_edge = self.find_edge(edge[0], edge[1])
-            if existing_edge and existing_edge[2] > edge[2]:
-                self.update_node(edge[0], edge[1], edge[2])
-            else:
-                self.register_edge(*edge)
-
-    def register_edge(self, left, right, cost):
-        if left != self.node_id:
-            self._nodes.add(left)
-        if right != self.node_id:
-            self._nodes.add(right)
-        edge = self.update_node(left, right, cost)
-        if not edge:
-            self._edges.add((*sorted([left, right]), cost))
-        route_info.info(dict(edges=str(self._edges)))
-
-    def update_node(self, left, right, cost):
-        edge = self.find_edge(left, right)
-        if edge:
-            new_edge = (edge[0], edge[1], cost)
-            self._edges.remove(edge)
-            self._edges.add(new_edge)
-            return edge
-        return None
+    def add_or_update_edges(self, edges):
+        """
+        Adds a list of edges supplied as (node1, node2, cost) tuples.
+        Already-existing edges have their cost set to the lesser of the existing or new cost.
+        Supplying a cost of None removes the edge.
+        """
+        for left, right, cost in edges:
+            edge_key = tuple(sorted([left, right]))
+            if edge_key not in self._edges:
+                self._neighbors[left].add(right)
+                self._neighbors[right].add(left)
+                for node in edge_key:
+                    if node != self.node_id:
+                        self._nodes.add(node)
+                self._edges[edge_key] = cost
+            elif cost is None:
+                del self._edges[edge_key]
+            elif cost < self._edges[edge_key]:
+                self._edges[edge_key] = cost
+        self.update_routing_table()
+        route_info.info(dict(edges=str(self.get_edges())))
 
     def remove_node(self, node):
-        edge = self.find_edge(self.node_id, node)
-        if edge:
-            self._edges.remove(edge)
-            return edge
-        return None
+        """Removes a node and its associated edges."""
+        edge_keys = [ek for ek in self._edges.keys() if ek[0] == node or ek[1] == node]
+        for ek in edge_keys:
+            del self._edges[ek]
+        if node in self._neighbors:
+            for neighbor in self._neighbors[node]:
+                if node in self._neighbors[neighbor]:
+                    self._neighbors[neighbor].remove(node)
+            del self._neighbors[node]
+        self._nodes.remove(node)
 
     def get_edges(self):
-        """Returns set of edges"""
-        return list(self._edges)
+        """Returns set of edges as a list of (node1, node2, cost) tuples."""
+        return [(ek[0], ek[1], cost) for ek, cost in self._edges.items()]
 
     def get_nodes(self):
-        return self._nodes
+        """Returns the list of nodes known to the router."""
+        return [node for node in self._nodes]
+
+    def get_neighbors(self, node):
+        """Returns the set of nodes which are neighbors of the given node."""
+        return self._neighbors[node]
+
+    def get_edge_cost(self, node1, node2):
+        """Returns the cost of the edge between node1 and node2."""
+        if node1 == node2:
+            return 0
+        node_key = tuple(sorted([node1, node2]))
+        if node_key in self._edges:
+            return self._edges[node_key]
+        else:
+            return None
+
+    def update_routing_table(self):
+        """Dijkstra's algorithm"""
+        Q = PriorityQueue()
+        Q.add_with_priority(self.node_id, 0)
+        cost = {self.node_id: 0}
+        prev = dict()
+
+        for node in self._nodes:
+            cost[node] = sys.maxsize   # poor man's infinity
+            prev[node] = None
+            Q.add_with_priority(node, cost[node])
+
+        while not Q.is_empty():
+            node = Q.pop_item()
+            for neighbor in self.get_neighbors(node):
+                path_cost = cost[node] + self.get_edge_cost(node, neighbor)
+                if path_cost < cost[neighbor]:
+                    cost[neighbor] = path_cost
+                    prev[neighbor] = node
+                    Q.add_with_priority(neighbor, path_cost)
+
+        new_routing_table = dict()
+        for dest in self._nodes:
+            p = dest
+            while prev[p] != self.node_id:
+                p = prev[p]
+            new_routing_table[dest] = (p, cost[dest])
+        self.routing_table = new_routing_table
+
+    def next_hop(self, recipient):
+        """
+        Return the node ID of the next hop for routing a message to the
+        given recipient. If the current node is the recipient or there is
+        no path, then return None.
+        """
+        if recipient in self.routing_table:
+            return self.routing_table[recipient][0]
+        else:
+            return None
 
     async def ping_node(self, node_id, expected_response=True):
         logger.info(f'Sending ping to node {node_id}')
@@ -89,33 +185,6 @@ class MeshRouter:
         )
         return await self.send(ping_envelope, expected_response)
 
-    def find_shortest_path(self, to_node_id):
-        """Implementation of Dijkstra algorithm"""
-        cost_map = defaultdict(list)
-        for left, right, cost in self._edges:
-            cost_map[left].append((cost, right))
-            cost_map[right].append((cost, left))
-
-        heap, seen, mins = [(0, self.node_id, [])], set(), {self.node_id: 0}
-        while heap:
-            (cost, vertex, path) = heapq.heappop(heap)
-            if vertex not in seen:
-                seen.add(vertex)
-                path = [vertex] + path
-                if vertex == to_node_id:
-                    logger.debug(f'Shortest path to {to_node_id} with cost {cost} is {path}')
-                    return path
-                cost_map_for_vertex = cost_map.get(vertex, ())
-                random.shuffle(cost_map_for_vertex)
-                for next_cost, next_vertex in cost_map.get(vertex, ()):
-                    if next_vertex in seen:
-                        continue
-                    min_so_far = mins.get(next_vertex, None)
-                    next_total_cost = cost + next_cost
-                    if min_so_far is None or next_total_cost < min_so_far:
-                        mins[next_vertex] = next_total_cost
-                        heapq.heappush(heap, (next_total_cost, next_vertex, path))
-
     async def forward(self, msg, next_hop):
         """
         Forward a message on to the next hop closer to its destination
@@ -132,18 +201,6 @@ class MeshRouter:
             # TODO: Possible to find another route? This might be a hard failure
         except Exception as e:
             logger.exception("Error trying to forward message to {}: {}".format(next_hop, e))
-
-    def next_hop(self, recipient):
-        """
-        Return the node ID of the next hop for routing a message to the
-        given recipient. If the current node is the recipient or there is
-        no path, then return None.
-        """
-        if recipient == self.node_id:
-            return None
-        path = self.find_shortest_path(recipient)
-        if path:
-            return path[-2]
 
     async def send(self, inner_envelope, expected_response=False):
         """

--- a/receptor/router.py
+++ b/receptor/router.py
@@ -93,7 +93,7 @@ class MeshRouter:
             else:
                 self._edges[edge_key] = cost
         self.update_routing_table()
-        route_info.info(dict(edges=str(self.get_edges())))
+        route_info.info(dict(edges=str(set(self.get_edges()))))
 
     def remove_node(self, node):
         """Removes a node and its associated edges."""
@@ -107,7 +107,7 @@ class MeshRouter:
             del self._neighbors[node]
         if node in self._nodes:
             self._nodes.remove(node)
-        route_info.info(dict(edges=str(self.get_edges())))
+        route_info.info(dict(edges=str(set(self.get_edges()))))
 
     def get_edges(self):
         """Returns set of edges as a list of (node1, node2, cost) tuples."""

--- a/test/unit/test_router.py
+++ b/test/unit/test_router.py
@@ -17,12 +17,14 @@ test_networks = [
     ),
 ]
 
+
 @pytest.mark.parametrize("edges, expected_next_hops, expected_neighbors", test_networks)
 def test_next_hop(edges, expected_next_hops, expected_neighbors):
     for node_id, remote, enh in expected_next_hops:
         r = MeshRouter(node_id=node_id)
         r.add_or_update_edges(edges)
         assert r.next_hop(remote) == enh
+
 
 @pytest.mark.parametrize("edges, expected_next_hops, expected_neighbors", test_networks)
 def test_neighbors(edges, expected_next_hops, expected_neighbors):

--- a/test/unit/test_router.py
+++ b/test/unit/test_router.py
@@ -1,0 +1,32 @@
+import pytest
+from receptor.router import MeshRouter
+
+test_networks = [
+    (
+        [('a', 'b', 1), ('a', 'd', 1), ('a', 'f', 1), ('b', 'd', 1), ('b', 'c', 1),
+         ('c', 'e', 1), ('c', 'h', 1), ('c', 'j', 1), ('e', 'f', 1), ('e', 'g', 1),
+         ('e', 'h', 1), ('f', 'g', 1), ('g', 'h', 1), ('h', 'j', 1), ('h', 'k', 1),
+         ('j', 'k', 1), ('j', 'm', 1), ('l', 'm', 1)],
+        [('a', 'f', 'f'), ('a', 'm', 'b'), ('h', 'd', 'c')],
+        [('a', {'b', 'd', 'f'}), ('f', {'a', 'e', 'g'}), ('j', {'c', 'h', 'k', 'm'})],
+    ),
+    (
+        [('a', 'b', 1), ('b', 'c', 1), ('c', 'd', 1), ('d', 'e', 1), ('e', 'f', 1)],
+        [('a', 'f', 'b'), ('c', 'a', 'b'), ('f', 'c', 'e')],
+        [('a', {'b'}), ('f', {'e'}), ('c', {'b', 'd'})],
+    ),
+]
+
+@pytest.mark.parametrize("edges, expected_next_hops, expected_neighbors", test_networks)
+def test_next_hop(edges, expected_next_hops, expected_neighbors):
+    for node_id, remote, enh in expected_next_hops:
+        r = MeshRouter(node_id=node_id)
+        r.add_or_update_edges(edges)
+        assert r.next_hop(remote) == enh
+
+@pytest.mark.parametrize("edges, expected_next_hops, expected_neighbors", test_networks)
+def test_neighbors(edges, expected_next_hops, expected_neighbors):
+    r = MeshRouter(node_id=edges[0][0])
+    r.add_or_update_edges(edges)
+    for node_id, neighbors in expected_neighbors:
+        assert r.get_neighbors(node_id) == neighbors


### PR DESCRIPTION
Dijkstra's algorithm efficiently finds _all_ shortest paths in a graph, all at once, from a single origin to every destination.  Our use of `find_shortest_path` for each destination node wastes this efficiency by unnecessarily running the algorithm multiple times.  Instead, we should run Dijkstra _once_ whenever the graph is modified.  Routing an individual packet then becomes a single dict lookup.

We are also currently broadcasting _neighbor_ information to _all known nodes_.  What we ought to be doing is broadcasting _all known node_ information to _neighbors_.  This is what I will work on next.

When complete, this PR is expected to fix https://github.com/project-receptor/receptor/issues/148 and maybe also https://github.com/project-receptor/receptor/issues/79.