### PR TITLE
Remove non-voting gate job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -4,10 +4,6 @@
       jobs:
         - ansible-tox-integration:
             voting: false
-    gate:
-      jobs:
-        - ansible-tox-integration:
-            voting: false
 
 - job:
     name: ansible-tox-integration


### PR DESCRIPTION
The results of non-voting jobs don't factor into merging code in the
gate pipeline. To help save CPU cycles, remove it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>