### PR TITLE
Speed up writing manifests

### DIFF
--- a/receptor/buffers/file.py
+++ b/receptor/buffers/file.py
@@ -70,7 +70,7 @@ class DurableBuffer:
 
     def _write_manifest(self):
         with open(self._manifest_path, "w") as fp:
-            json.dump(list(self.q._queue), fp, default=encode_date)
+            fp.write(json.dumps(list(self.q._queue), default=encode_date))
 
     def _read_manifest(self):
         try:


### PR DESCRIPTION
For in-memory data, `fp.write(json.dumps(data))` is considerably faster than `json.dump(data, fp)` because `json.dump()` makes individual operating system write calls for every parsed element (including separate calls for each `[` and `]`).

On my system this resulted in the following improvement:

Before:
```
receptor --node-id foo node & sleep 1 && time receptor ping foo --count 1000 --delay 0 > /dev/null && killall receptor
[1] 55329

real    0m5.265s
user    0m2.704s
sys     0m3.656s
[1]+  Terminated              receptor --node-id foo node
```

After:
```
receptor --node-id foo node & sleep 1 && time receptor ping foo --count 1000 --delay 0 > /dev/null && killall receptor
[1] 55450

real    0m2.988s
user    0m0.919s
sys     0m2.635s
[1]+  Terminated              receptor --node-id foo node
```