### PR TITLE
Add ws_extra_header option

### DIFF
--- a/receptor/config.py
+++ b/receptor/config.py
@@ -472,8 +472,7 @@ class ReceptorConfig:
                 if not isinstance(entry.value, list):
                     entry.value = entry.value.split(',')
                 if entry.value_type == 'key-value-list':
-                    entry.value = [(key.strip(), value.strip()) for key, sep, value in
-                         [s.partition(':') for s in entry.value]]
+                    entry.value = [(key.strip(), value.strip()) for key, sep, value in [s.partition(':') for s in entry.value]]
                 else:
                     for idx, value in enumerate(entry.value):
                         entry.value[idx] = self._enforce_value_type(value, entry.listof)

--- a/receptor/config.py
+++ b/receptor/config.py
@@ -186,6 +186,15 @@ class ReceptorConfig:
         )
         self.add_config_option(
             section='node',
+            key='ws_extra_headers',
+            long_option='--ws_extra_header',
+            default_value=[],
+            value_type='key-value-list',
+            listof='str',
+            hint='Set additional headers to provide when connecting to websocket peers.',
+        )
+        self.add_config_option(
+            section='node',
             key='server_disable',
             default_value=False,
             value_type='bool',
@@ -228,7 +237,7 @@ class ReceptorConfig:
             key='ws_extra_headers',
             long_option='--ws_extra_header',
             default_value=[],
-            value_type='list',
+            value_type='key-value-list',
             listof='str',
             hint='Set additional headers to provide when connecting to websocket peers.',
         )
@@ -261,7 +270,7 @@ class ReceptorConfig:
             key='ws_extra_headers',
             long_option='--ws_extra_header',
             default_value=[],
-            value_type='list',
+            value_type='key-value-list',
             listof='str',
             hint='Set additional headers to provide when connecting to websocket peers.',
         )
@@ -318,7 +327,7 @@ class ReceptorConfig:
             key='ws_extra_headers',
             long_option='--ws_extra_header',
             default_value=[],
-            value_type='list',
+            value_type='key-value-list',
             listof='str',
             hint='Set additional headers to provide when connecting to websocket peers.',
         )
@@ -350,7 +359,7 @@ class ReceptorConfig:
         if cli:
             # for lists, we switch the action from 'store' to 'append'
             action = 'store'
-            if value_type == 'list':
+            if value_type == 'list' or value_type == 'key-value-list':
                 action = 'append'
             if value_type == 'bool':
                 action = 'store_const'
@@ -459,11 +468,15 @@ class ReceptorConfig:
 
     def _enforce_entry_type(self, entry):
         if entry.value is not None:
-            if entry.value_type == 'list':
+            if entry.value_type == 'list' or entry.value_type == 'key-value-list':
                 if not isinstance(entry.value, list):
                     entry.value = entry.value.split(',')
-                for idx, value in enumerate(entry.value):
-                    entry.value[idx] = self._enforce_value_type(value, entry.listof)
+                if entry.value_type == 'key-value-list':
+                    entry.value = [(key.strip(), value.strip()) for key, sep, value in
+                         [s.partition(':') for s in entry.value]]
+                else:
+                    for idx, value in enumerate(entry.value):
+                        entry.value[idx] = self._enforce_value_type(value, entry.listof)
             else:
                 entry.value = self._enforce_value_type(entry.value, entry.value_type)
 

--- a/receptor/config.py
+++ b/receptor/config.py
@@ -223,6 +223,15 @@ class ReceptorConfig:
             listof='str',
             hint='Define membership in one or more groups to aid in message routing',
         )
+        self.add_config_option(
+            section='node',
+            key='ws_extra_headers',
+            long_option='--ws_extra_header',
+            default_value=[],
+            value_type='list',
+            listof='str',
+            hint='Set additional headers to provide when connecting to websocket peers.',
+        )
         # ping options
         self.add_config_option(
             section='ping',
@@ -246,6 +255,15 @@ class ReceptorConfig:
             default_value='',
             value_type='str',
             hint='Node ID of the Receptor node to ping.',
+        )
+        self.add_config_option(
+            section='ping',
+            key='ws_extra_headers',
+            long_option='--ws_extra_header',
+            default_value=[],
+            value_type='list',
+            listof='str',
+            hint='Set additional headers to provide when connecting to websocket peers.',
         )
         # send options
         self.add_config_option(
@@ -278,6 +296,15 @@ class ReceptorConfig:
             value_type='str',
             hint='Payload of the directive to send. Use - for stdin or give the path to a file to transmit the file contents.',
         )
+        self.add_config_option(
+            section='send',
+            key='ws_extra_headers',
+            long_option='--ws_extra_header',
+            default_value=[],
+            value_type='list',
+            listof='str',
+            hint='Set additional headers to provide when connecting to websocket peers.',
+        )
         # status options
         self.add_config_option(
             section='status',
@@ -285,6 +312,15 @@ class ReceptorConfig:
             default_value='localhost:8888',
             value_type='str',
             hint='The peer to access the mesh through. If unspecified here or in a config file, localhost:8888 will be used.'
+        )
+        self.add_config_option(
+            section='status',
+            key='ws_extra_headers',
+            long_option='--ws_extra_header',
+            default_value=[],
+            value_type='list',
+            listof='str',
+            hint='Set additional headers to provide when connecting to websocket peers.',
         )
         # Component options. These are also only used in a config section
         # like auth, so they also set `subparse=False`.

--- a/receptor/config.py
+++ b/receptor/config.py
@@ -186,15 +186,6 @@ class ReceptorConfig:
         )
         self.add_config_option(
             section='node',
-            key='ws_extra_headers',
-            long_option='--ws_extra_header',
-            default_value=[],
-            value_type='key-value-list',
-            listof='str',
-            hint='Set additional headers to provide when connecting to websocket peers.',
-        )
-        self.add_config_option(
-            section='node',
             key='server_disable',
             default_value=False,
             value_type='bool',
@@ -238,7 +229,6 @@ class ReceptorConfig:
             long_option='--ws_extra_header',
             default_value=[],
             value_type='key-value-list',
-            listof='str',
             hint='Set additional headers to provide when connecting to websocket peers.',
         )
         # ping options
@@ -271,7 +261,6 @@ class ReceptorConfig:
             long_option='--ws_extra_header',
             default_value=[],
             value_type='key-value-list',
-            listof='str',
             hint='Set additional headers to provide when connecting to websocket peers.',
         )
         # send options
@@ -311,7 +300,6 @@ class ReceptorConfig:
             long_option='--ws_extra_header',
             default_value=[],
             value_type='list',
-            listof='str',
             hint='Set additional headers to provide when connecting to websocket peers.',
         )
         # status options

--- a/receptor/connection/manager.py
+++ b/receptor/connection/manager.py
@@ -47,7 +47,7 @@ class Manager:
         else:
             raise RuntimeError(f"Unknown URL scheme {service.scheme}")
 
-    def get_peer(self, peer, reconnect=True):
+    def get_peer(self, peer, reconnect=True, ws_extra_headers=None):
         service = parse_peer(peer)
         ssl_context = self.ssl_context_factory("client") if service.scheme in ("rnps", "wss") else None
         if service.scheme in ("rnp", "rnps"):
@@ -55,6 +55,6 @@ class Manager:
                                          self.loop, ssl_context, reconnect))
         elif service.scheme in ("ws", "wss"):
             return self.loop.create_task(ws.connect(peer, self.factory, self.loop,
-                                         ssl_context, reconnect))
+                                         ssl_context, reconnect, ws_extra_headers))
         else:
             raise RuntimeError(f"Unknown URL scheme {service.scheme}")

--- a/receptor/connection/ws.py
+++ b/receptor/connection/ws.py
@@ -32,7 +32,6 @@ async def connect(uri, factory, loop=None, ssl_context=None, reconnect=True, ws_
     if not loop:
         loop = asyncio.get_event_loop()
 
-    print("------------------------------ In connect --------------------------")
     worker = factory()
     try:
         extra_headers = [(key.strip(), value.strip()) for key, sep, value in

--- a/receptor/connection/ws.py
+++ b/receptor/connection/ws.py
@@ -28,13 +28,17 @@ class WebSocket(Transport):
         await self.ws.send_bytes(bytes_)
 
 
-async def connect(uri, factory, loop=None, ssl_context=None, reconnect=True):
+async def connect(uri, factory, loop=None, ssl_context=None, reconnect=True, ws_extra_headers=None):
     if not loop:
         loop = asyncio.get_event_loop()
 
+    print("------------------------------ In connect --------------------------")
     worker = factory()
     try:
-        async with aiohttp.ClientSession().ws_connect(uri, ssl=ssl_context) as ws:
+        extra_headers = [(key.strip(), value.strip()) for key, sep, value in
+                         [s.partition(':') for s in ws_extra_headers]]
+        async with aiohttp.ClientSession().ws_connect(uri, ssl=ssl_context,
+                                                      headers=extra_headers) as ws:
             log_ssl_detail(ws)
             t = WebSocket(ws)
             await worker.client(t)

--- a/receptor/connection/ws.py
+++ b/receptor/connection/ws.py
@@ -34,10 +34,8 @@ async def connect(uri, factory, loop=None, ssl_context=None, reconnect=True, ws_
 
     worker = factory()
     try:
-        extra_headers = [(key.strip(), value.strip()) for key, sep, value in
-                         [s.partition(':') for s in ws_extra_headers]]
         async with aiohttp.ClientSession().ws_connect(uri, ssl=ssl_context,
-                                                      headers=extra_headers) as ws:
+                                                      headers=ws_extra_headers) as ws:
             log_ssl_detail(ws)
             t = WebSocket(ws)
             await worker.client(t)

--- a/receptor/controller.py
+++ b/receptor/controller.py
@@ -56,9 +56,10 @@ class Controller:
             tasks.append(self.loop.create_task(listener))
         return tasks
 
-    def add_peer(self, peer):
+    def add_peer(self, peer, ws_extra_headers=None):
         logger.info("Connecting to peer {}".format(peer))
-        return self.connection_manager.get_peer(peer, reconnect=not self.receptor.config._is_ephemeral)
+        return self.connection_manager.get_peer(peer, reconnect=not self.receptor.config._is_ephemeral,
+                                                ws_extra_headers=ws_extra_headers)
 
     async def recv(self):
         return await self.receptor.response_queue.get()

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -49,7 +49,7 @@ def run_as_node(config):
             listen_tasks = controller.enable_server(config.node_listen)
             controller.loop.create_task(controller.exit_on_exceptions_in(listen_tasks))
         for peer in config.node_peers:
-            controller.add_peer(peer)
+            controller.add_peer(peer, ws_extra_headers=config.node_ws_extra_headers)
         if config.node_keepalive_interval > 1:
             controller.loop.create_task(node_keepalive())
         controller.loop.create_task(controller.receptor.watch_expire())
@@ -58,8 +58,8 @@ def run_as_node(config):
         cleanup_tmpdir(controller)
 
 
-async def run_oneshot_command(controller, peer, recipient, send_func, read_func):
-    add_peer_task = controller.add_peer(peer)
+async def run_oneshot_command(controller, peer, recipient, ws_extra_headers, send_func, read_func):
+    add_peer_task = controller.add_peer(peer, ws_extra_headers=ws_extra_headers)
     start_wait = time.time()
     while True:
         if add_peer_task and add_peer_task.done() and not add_peer_task.result():
@@ -89,7 +89,8 @@ def run_as_ping(config):
                 yield 0
 
     async def ping_entrypoint():
-        return await run_oneshot_command(controller, config.ping_peer, config.ping_recipient, send_pings, read_responses)
+        return await run_oneshot_command(controller, config.ping_peer, config.ping_recipient,
+                                         config.ping_ws_extra_headers, send_pings, read_responses)
 
     async def read_responses():
         for _ in ping_iter():
@@ -111,7 +112,8 @@ def run_as_ping(config):
 
 def run_as_send(config):
     async def send_entrypoint():
-        return await run_oneshot_command(controller, config.send_peer, config.send_recipient, send_message, read_responses)
+        return await run_oneshot_command(controller, config.send_peer, config.send_recipient,
+                                         config.ws_extra_headers, send_message, read_responses)
 
     async def send_message():
         msg = Message(config.send_recipient, config.send_directive)
@@ -152,7 +154,8 @@ def run_as_send(config):
 def run_as_status(config):
 
     async def status_entrypoint():
-        return await run_oneshot_command(controller, config.status_peer, None, print_status, noop)
+        return await run_oneshot_command(controller, config.status_peer, None,
+                                         config.status_ws_extra_headers, print_status, noop)
 
     async def print_status():
 


### PR DESCRIPTION
This adds the `--ws_extra_header` command line and config file option.  When used as follows:
```
receptor ping foo --peer ws://localhost:1234 --ws_extra_header=x-special-auth:supersecret --ws_extra_header=foo:bar
```
this will cause the Receptor client to include `x-special-auth` and `foo` HTTP headers on initial connection to its websocket peer.  When regular sockets are used, this option has no effect.

See issue https://github.com/project-receptor/receptor/issues/151.
