### PR TITLE
Remove the completed work from the active_work list whether it caused an exception or not

### DIFF
--- a/receptor/work.py
+++ b/receptor/work.py
@@ -112,7 +112,9 @@ class WorkManager:
                 code=1,
                 message_type="eof",
             )
-            self.remove_work(inner_env)
+
+        self.remove_work(inner_env)
+
         if eof_response is None:
             eof_response = envelope.Inner.make_response(
                 receptor=self.receptor,


### PR DESCRIPTION
Right now it looks like the remove_work() method is only called in the case of an exception.