### PR TITLE
Add the ability to send multiple (identical) messages

### DIFF
--- a/receptor/config.py
+++ b/receptor/config.py
@@ -264,6 +264,13 @@ class ReceptorConfig:
         )
         self.add_config_option(
             section='send',
+            key='repeats',
+            default_value='1',
+            value_type='int',
+            hint='Number of times to repeatedly send the same message. Defaults to 1.',
+        )
+        self.add_config_option(
+            section='send',
             key='recipient',
             long_option='send_recipient',
             default_value='',


### PR DESCRIPTION
This adds a `--repeats` option to `receptor send` that will send multiple copies of the same message.  This is only really useful for testing, so maybe we don't want this in the main codebase.