### PR TITLE
Restore ping --peer command also deleted by PR # 160

### DIFF
--- a/receptor/config.py
+++ b/receptor/config.py
@@ -226,6 +226,13 @@ class ReceptorConfig:
         # ping options
         self.add_config_option(
             section='ping',
+            key='peer',
+            default_value='localhost:8888',
+            value_type='str',
+            hint='The peer to relay the ping directive through. If unspecified here or in a config file, localhost:8888 will be used.'
+        )
+        self.add_config_option(
+            section='ping',
             key='count',
             default_value=4,
             value_type='int',


### PR DESCRIPTION
In PR # 160 I tried to reorder the config options to be better organized.  Apparently I missed stuff.