### PR TITLE
Relax the requirement for TLS 1.3

### DIFF
--- a/receptor/config.py
+++ b/receptor/config.py
@@ -528,7 +528,7 @@ class ReceptorConfig:
         ca_bundle = self.auth_server_ca_bundle
         ca_bundle = ca_bundle if ca_bundle else None   # Make false-like values like '' explicitly None
         sc = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        sc.options |= ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_TLSv1_2
+        sc.options |= ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
         if self.auth_client_cipher_list:
             sc.set_ciphers(self.auth_client_cipher_list)
         sc.verify_mode = ssl.CERT_REQUIRED


### PR DESCRIPTION
The OpenSSL version shipped with RHEL7 only supports TLS 1.2, so we can't disallow it here without breaking Receptor on RHEL7.