### PR TITLE
Retain websocket client headers between connection restarts

### DIFF
--- a/receptor/connection/ws.py
+++ b/receptor/connection/ws.py
@@ -46,7 +46,7 @@ async def connect(uri, factory, loop=None, ssl_context=None, reconnect=True, ws_
         if reconnect:
             await asyncio.sleep(5)
             logger.debug("ws.connect: reconnecting")
-            loop.create_task(connect(uri, factory=factory, loop=loop, ssl_context=ssl_context))
+            loop.create_task(connect(uri, factory=factory, loop=loop, ssl_context=ssl_context, ws_extra_headers=ws_extra_headers))
         return True
 
 


### PR DESCRIPTION
Fix an issue where the extra headers that are passed to the websocket client are lost when the websocket connection is restarted