### PR TITLE
Send header as well as data to worker plugins

### DIFF
--- a/receptor/work.py
+++ b/receptor/work.py
@@ -107,6 +107,7 @@ class WorkManager:
             asyncio.wrap_future(
                 self.thread_pool.submit(
                     action_method,
+                    message.header,
                     self.resolve_payload_input(payload_input_type, message.payload),
                     self.receptor.config.plugins.get(namespace, {}),
                     response_queue,


### PR DESCRIPTION
Non-trivial worker plugins are going to need to see header fields, not just the payload.  Without this they cannot see, for example, who sent the message.  (Either that, or the worker's protocol is going to need to uselessly duplicate this header information in their payload format.)

This changes the function signature to the workers, which of course breaks existing workers.  We could avoid breaking existing workers with kwargs, but this is the most sensible and natural way to pass the information, so I'd rather just fix the (few) workers that already exist.