### PR TITLE
Allow TLS 1.2 consistently between server and client

### DIFF
--- a/receptor/config.py
+++ b/receptor/config.py
@@ -554,13 +554,7 @@ class ReceptorConfig:
             ca_bundle if ca_bundle else None
         )  # Make false-like values like '' explicitly None
         sc = ssl.SSLContext(ssl.PROTOCOL_TLS)
-        sc.options |= (
-            ssl.OP_NO_SSLv2
-            | ssl.OP_NO_SSLv3
-            | ssl.OP_NO_TLSv1
-            | ssl.OP_NO_TLSv1_1
-            | ssl.OP_NO_TLSv1_2
-        )
+        sc.options |= ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
         if self.auth_server_cipher_list:
             sc.set_ciphers(self.auth_server_cipher_list)
         if self.auth_client_verification_ca:


### PR DESCRIPTION
When I relaxed the requirement for TLS 1.3 for OpenSSL versions that don't include it, I only made the change in the client context, and should have changed it in both server and client.