### PR TITLE
Adding a diagnostics subsystem

### DIFF
--- a/receptor/__main__.py
+++ b/receptor/__main__.py
@@ -3,8 +3,10 @@ import logging
 import logging.config
 import signal
 import sys
+from collections import deque
 
 from .config import ReceptorConfig
+from .diagnostics import log_buffer
 from .logstash_formatter.logstash import LogstashFormatter
 
 logger = logging.getLogger(__name__)
@@ -48,6 +50,8 @@ def main(args=None):
 
     def _f(record):
         record.node_id = config.default_node_id
+        if record.levelno == logging.ERROR:
+            log_buffer.appendleft(record)
         return True
 
     for h in logging.getLogger("receptor").handlers:

--- a/receptor/__main__.py
+++ b/receptor/__main__.py
@@ -1,9 +1,7 @@
 import asyncio
 import logging
 import logging.config
-import signal
 import sys
-from collections import deque
 
 from .config import ReceptorConfig
 from .diagnostics import log_buffer

--- a/receptor/__main__.py
+++ b/receptor/__main__.py
@@ -57,12 +57,6 @@ def main(args=None):
     for h in logging.getLogger("receptor").handlers:
         h.addFilter(_f)
 
-    def dump_stacks(signum, frame):
-        for t in asyncio.Task.all_tasks():
-            t.print_stack(file=sys.stderr)
-
-    signal.signal(signal.SIGHUP, dump_stacks)
-
     try:
         config.go()
     except asyncio.CancelledError:

--- a/receptor/config.py
+++ b/receptor/config.py
@@ -246,7 +246,7 @@ class ReceptorConfig:
             long_option="--ws_heartbeat",
             default_value=None,
             value_type="int",
-            hint="Set heartbeat interval for websocket connections."
+            hint="Set heartbeat interval for websocket connections.",
         )
         # ping options
         self.add_config_option(
@@ -295,7 +295,7 @@ class ReceptorConfig:
             long_option="--ws_heartbeat",
             default_value=None,
             value_type="int",
-            hint="Set heartbeat interval for websocket connections."
+            hint="Set heartbeat interval for websocket connections.",
         )
         # send options
         self.add_config_option(
@@ -344,7 +344,7 @@ class ReceptorConfig:
             long_option="--ws_heartbeat",
             default_value=None,
             value_type="int",
-            hint="Set heartbeat interval for websocket connections."
+            hint="Set heartbeat interval for websocket connections.",
         )
         # status options
         self.add_config_option(
@@ -378,7 +378,7 @@ class ReceptorConfig:
             long_option="--ws_heartbeat",
             default_value=None,
             value_type="int",
-            hint="Set heartbeat interval for websocket connections."
+            hint="Set heartbeat interval for websocket connections.",
         )
         self.parse_options(args)
 

--- a/receptor/connection/base.py
+++ b/receptor/connection/base.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator
 from .. import fileio
 from ..bridgequeue import BridgeQueue
 from ..messages.framed import FramedBuffer
+from ..serde import encode
 
 logger = logging.getLogger(__name__)
 

--- a/receptor/connection/base.py
+++ b/receptor/connection/base.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncIterator
 from .. import fileio
 from ..bridgequeue import BridgeQueue
 from ..messages.framed import FramedBuffer
-from ..serde import encode
+from ..stats import bytes_recv
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +60,7 @@ class Worker:
             async for msg in self.conn:
                 if self.conn.closed:
                     break
+                bytes_recv.inc(len(msg))
                 await self.buf.put(msg)
         except ConnectionResetError:
             logger.debug("receive: other side closed the connection")

--- a/receptor/connection/sock.py
+++ b/receptor/connection/sock.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+
+from ..serde import encode
 from .base import Transport, log_ssl_detail
 
 logger = logging.getLogger(__name__)
@@ -30,6 +32,11 @@ class RawSocket(Transport):
         async for chunk in q:
             self.writer.write(chunk)
         await self.writer.drain()
+
+
+@encode.register(RawSocket)
+def encode_rawsocket(o):
+    return {"extra": o.writer.get_extra_info(), "closed": o.closed, "chunk_size": o.chunk_size}
 
 
 async def connect(host, port, factory, loop=None, ssl=None, reconnect=True):

--- a/receptor/connection/sock.py
+++ b/receptor/connection/sock.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 
-from ..serde import encode
 from .base import Transport, log_ssl_detail
 
 logger = logging.getLogger(__name__)
@@ -33,21 +32,19 @@ class RawSocket(Transport):
             self.writer.write(chunk)
         await self.writer.drain()
 
-
-@encode.register(RawSocket)
-def encode_rawsocket(o):
-    t = o.writer._transport.get_extra_info
-    addr, port = t("peername", (None, None))
-    return {
-        "address": addr,
-        "port": port,
-        "compression": t("compression"),
-        "cipher": t("cipher"),
-        "peercert": t("peercert"),
-        "sslcontext": t("sslcontext"),
-        "closed": o.closed,
-        "chunk_size": o.chunk_size,
-    }
+    def _diagnostics(self):
+        t = self.writer._transport.get_extra_info
+        addr, port = t("peername", (None, None))
+        return {
+            "address": addr,
+            "port": port,
+            "compression": t("compression"),
+            "cipher": t("cipher"),
+            "peercert": t("peercert"),
+            "sslcontext": t("sslcontext"),
+            "closed": self.closed,
+            "chunk_size": self.chunk_size,
+        }
 
 
 async def connect(host, port, factory, loop=None, ssl=None, reconnect=True):

--- a/receptor/connection/sock.py
+++ b/receptor/connection/sock.py
@@ -36,7 +36,18 @@ class RawSocket(Transport):
 
 @encode.register(RawSocket)
 def encode_rawsocket(o):
-    return {"extra": o.writer.get_extra_info(), "closed": o.closed, "chunk_size": o.chunk_size}
+    t = o.writer._transport.get_extra_info
+    addr, port = t("peername", (None, None))
+    return {
+        "address": addr,
+        "port": port,
+        "compression": t("compression"),
+        "cipher": t("cipher"),
+        "peercert": t("peercert"),
+        "sslcontext": t("sslcontext"),
+        "closed": o.closed,
+        "chunk_size": o.chunk_size,
+    }
 
 
 async def connect(host, port, factory, loop=None, ssl=None, reconnect=True):

--- a/receptor/connection/ws.py
+++ b/receptor/connection/ws.py
@@ -33,15 +33,20 @@ class WebSocket(Transport):
 
 
 async def connect(
-    uri, factory, loop=None, ssl_context=None, reconnect=True,
-    ws_extra_headers=None, ws_heartbeat=None
+    uri,
+    factory,
+    loop=None,
+    ssl_context=None,
+    reconnect=True,
+    ws_extra_headers=None,
+    ws_heartbeat=None,
 ):
     if not loop:
         loop = asyncio.get_event_loop()
 
     worker = factory()
     try:
-        proxy_scheme = {'ws': 'http', 'wss': 'https'}[urlparse(uri).scheme]
+        proxy_scheme = {"ws": "http", "wss": "https"}[urlparse(uri).scheme]
         proxies = proxies_from_env()
         if proxy_scheme in proxies:
             proxy = proxies[proxy_scheme].proxy
@@ -50,8 +55,12 @@ async def connect(
             proxy = None
             proxy_auth = None
         async with aiohttp.ClientSession().ws_connect(
-            uri, ssl=ssl_context, headers=ws_extra_headers,
-            proxy=proxy, proxy_auth=proxy_auth, heartbeat=ws_heartbeat
+            uri,
+            ssl=ssl_context,
+            headers=ws_extra_headers,
+            proxy=proxy,
+            proxy_auth=proxy_auth,
+            heartbeat=ws_heartbeat,
         ) as ws:
             log_ssl_detail(ws)
             t = WebSocket(ws)

--- a/receptor/controller.py
+++ b/receptor/controller.py
@@ -8,6 +8,7 @@ from contextlib import suppress
 
 from .connection.base import Worker
 from .connection.manager import Manager
+from .diagnostics import status
 from .messages.framed import FileBackedBuffer, FramedMessage
 from .receptor import Receptor
 
@@ -39,6 +40,7 @@ class Controller:
         if self.queue is None:
             self.queue = asyncio.Queue(loop=loop)
         self.receptor.response_queue = self.queue
+        self.status_task = loop.create_task(status(self.receptor))
 
     async def shutdown_loop(self):
         tasks = [

--- a/receptor/diagnostics.py
+++ b/receptor/diagnostics.py
@@ -3,6 +3,7 @@ import logging
 import os
 from collections import deque
 from datetime import datetime
+import signal
 
 from . import fileio, serde
 from .logstash_formatter.logstash import LogstashFormatter
@@ -11,6 +12,9 @@ logger = logging.getLogger(__name__)
 
 log_buffer = deque(maxlen=10)
 fmt = LogstashFormatter()
+trigger = asyncio.Event()
+
+signal.signal(signal.SIGHUP, lambda n, h: trigger.set())
 
 
 async def status(receptor_object):
@@ -18,11 +22,19 @@ async def status(receptor_object):
     doc = {}
     doc["config"] = receptor_object.config._parsed_args.__dict__
     while True:
+        trigger.clear()
         doc["datetime"] = datetime.utcnow().isoformat()
         doc["recent_errors"] = list(fmt._record_to_dict(r) for r in log_buffer)
         doc["connections"] = receptor_object.connections
+        doc["routes"] = receptor_object.router
+        doc["tasks"] = list(asyncio.Task.all_tasks())
         try:
             await fileio.write(path, serde.force_dumps(doc), mode="w")
         except Exception:
             logger.exception("failed to dump diagnostic data")
-        await asyncio.sleep(30)
+
+        # run every 30 seconds, or when triggered
+        try:
+            await asyncio.wait_for(trigger.wait(), 30)
+        except asyncio.TimeoutError:
+            pass

--- a/receptor/diagnostics.py
+++ b/receptor/diagnostics.py
@@ -1,11 +1,19 @@
 import asyncio
+import inspect
+import json
 import logging
 import os
-from collections import deque
-from datetime import datetime
 import signal
+import traceback as tb
+import types
+from collections import defaultdict, deque
+from datetime import datetime
+from functools import singledispatch
 
-from . import fileio, serde
+from prometheus_client.metrics_core import Metric
+from prometheus_client.registry import REGISTRY
+
+from . import fileio
 from .logstash_formatter.logstash import LogstashFormatter
 
 logger = logging.getLogger(__name__)
@@ -17,19 +25,118 @@ trigger = asyncio.Event()
 signal.signal(signal.SIGHUP, lambda n, h: trigger.set())
 
 
+@singledispatch
+def extract_module(o):
+    return o.__module__
+
+
+@extract_module.register(types.CoroutineType)
+def extract_coro(coro):
+    return inspect.getmodule(coro, coro.cr_code.co_filename).__name__
+
+
+@extract_module.register(types.GeneratorType)
+def extract_gen(gen):
+    return inspect.getmodule(gen, gen.gi_code.co_filename).__name__
+
+
+@singledispatch
+def encode(o):
+    return json.JSONEncoder().default(o)
+
+
+@encode.register(set)
+def encode_set(s):
+    return list(s)
+
+
+@encode.register(types.FunctionType)
+def encode_function_type(func):
+    return f"{func.__module__}.{func.__qualname__}"
+
+
+@encode.register(datetime)
+def encode_datetime(o):
+    return o.isoformat()
+
+
+def structure_task(task):
+    coro = task._coro
+    try:
+        mod = extract_module(coro)
+    except Exception:
+        mod = "<unknown>"
+
+    out = {"state": task._state, "name": f"{mod}.{coro.__qualname__}", "stack": []}
+
+    try:
+        stack = tb.extract_stack(task.get_stack()[0])
+        out["stack"] = [
+            {"filename": fs.filename, "line": fs.line, "lineno": fs.lineno} for fs in stack
+        ]
+    except IndexError:
+        pass
+
+    return out
+
+
+def tasks():
+    d = defaultdict(list)
+    for t in asyncio.Task.all_tasks():
+        st = structure_task(t)
+        state = st.pop("state")
+        d[state].append(st)
+    return [{"state": state, "items": tasks} for state, tasks in d.items()]
+
+
+def format_connection(node_id, connection, capabilities):
+    d = connection._diagnostics()
+    d["node_id"] = node_id
+    d["capabilities"] = capabilities
+    return d
+
+
+def format_router(router):
+    edges = [
+        {"left": edge[0], "right": edge[1], "cost": cost} for edge, cost in router._edges.items()
+    ]
+
+    neighbors = [
+        {"node_id": node_id, "items": values} for node_id, values in router._neighbors.items()
+    ]
+
+    table = [
+        {"destination_node_id": node_id, "next_hop": v[0], "cost": v[1]}
+        for node_id, v in router.routing_table.items()
+    ]
+
+    return {"nodes": router._nodes, "edges": edges, "neighbors": neighbors, "table": table}
+
+
+@encode.register(Metric)
+def encode_metric(m):
+    return {"name": m.name, "type": m.type, "samples": [s._asdict() for s in m.samples]}
+
+
 async def status(receptor_object):
     path = os.path.join(receptor_object.base_path, "diagnostics.json")
     doc = {}
     doc["config"] = receptor_object.config._parsed_args.__dict__
+    doc["node_id"] = receptor_object.node_id
     while True:
         trigger.clear()
-        doc["datetime"] = datetime.utcnow().isoformat()
+        doc["datetime"] = datetime.utcnow()
         doc["recent_errors"] = list(fmt._record_to_dict(r) for r in log_buffer)
-        doc["connections"] = receptor_object.connections
-        doc["routes"] = receptor_object.router
-        doc["tasks"] = list(asyncio.Task.all_tasks())
+        doc["connections"] = [
+            format_connection(node_id, conn, receptor_object.node_capabilities[node_id])
+            for node_id, connections in receptor_object.connections.items()
+            for conn in connections
+        ]
+        doc["routes"] = format_router(receptor_object.router)
+        doc["tasks"] = tasks()
+        doc["metrics"] = list(REGISTRY.collect())
         try:
-            await fileio.write(path, serde.force_dumps(doc), mode="w")
+            await fileio.write(path, json.dumps(doc, default=encode), mode="w")
         except Exception:
             logger.exception("failed to dump diagnostic data")
 

--- a/receptor/diagnostics.py
+++ b/receptor/diagnostics.py
@@ -1,0 +1,28 @@
+import asyncio
+import logging
+import os
+from collections import deque
+from datetime import datetime
+
+from . import fileio, serde
+from .logstash_formatter.logstash import LogstashFormatter
+
+logger = logging.getLogger(__name__)
+
+log_buffer = deque(maxlen=10)
+fmt = LogstashFormatter()
+
+
+async def status(receptor_object):
+    path = os.path.join(receptor_object.base_path, "diagnostics.json")
+    doc = {}
+    doc["config"] = receptor_object.config._parsed_args.__dict__
+    while True:
+        doc["datetime"] = datetime.utcnow().isoformat()
+        doc["recent_errors"] = list(fmt._record_to_dict(r) for r in log_buffer)
+        doc["connections"] = receptor_object.connections
+        try:
+            await fileio.write(path, serde.force_dumps(doc), mode="w")
+        except Exception:
+            logger.exception("failed to dump diagnostic data")
+        await asyncio.sleep(30)

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -35,7 +35,7 @@ def run_as_node(config):
             controller.add_peer(
                 peer,
                 ws_extra_headers=config.node_ws_extra_headers,
-                ws_heartbeat=config.node_ws_heartbeat
+                ws_heartbeat=config.node_ws_heartbeat,
             )
         if config.node_keepalive_interval > 1:
             controller.loop.create_task(node_keepalive())
@@ -179,7 +179,7 @@ def run_as_status(config):
             config.status_ws_extra_headers,
             config.status_ws_heartbeat,
             print_status,
-            noop
+            noop,
         )
 
     async def print_status():

--- a/receptor/logstash_formatter/logstash.py
+++ b/receptor/logstash_formatter/logstash.py
@@ -58,13 +58,7 @@ class LogstashFormatter(logging.Formatter):
             except Exception:
                 self.source_host = ""
 
-    def format(self, record):
-        """
-        Format a log record to JSON, if the message is a dict
-        assume an empty message and use the dict as additional
-        fields.
-        """
-
+    def _record_to_dict(self, record):
         fields = record.__dict__.copy()
 
         if isinstance(record.msg, dict):
@@ -107,7 +101,16 @@ class LogstashFormatter(logging.Formatter):
                 "@fields": self._build_fields(logr, fields),
             }
         )
+        return logr
 
+    def format(self, record):
+        """
+        Format a log record to JSON, if the message is a dict
+        assume an empty message and use the dict as additional
+        fields.
+        """
+
+        logr = self._record_to_dict(record)
         return json.dumps(logr, default=self.json_default, cls=self.json_cls)
 
     def _build_fields(self, defaults, fields):

--- a/receptor/receptor.py
+++ b/receptor/receptor.py
@@ -1,10 +1,10 @@
 import asyncio
+import collections
 import json
 import logging
 import os
 import time
 import uuid
-import collections
 
 import pkg_resources
 
@@ -148,12 +148,11 @@ class Receptor:
             self.connections[id_] = [protocol_obj]
             routing_changed = True
         await self.connection_manifest.update(id_)
-<<<<<<< HEAD
+
         if routing_changed:
             await self.recalculate_and_send_routes_soon()
-=======
+
         stats.connected_peers_gauge.inc()
->>>>>>> 943b3d5... refactoring module extraction
 
     async def remove_ephemeral(self, node):
         logger.debug(f"Removing ephemeral node {node}")
@@ -179,17 +178,9 @@ class Receptor:
                 else:
                     self.connections[connection_node].remove(protocol_obj)
                     await self.connection_manifest.update(connection_node)
-<<<<<<< HEAD
         if routing_changed:
             await self.recalculate_and_send_routes_soon()
-=======
-                stats.connected_peers_gauge.dec()
-            notify_connections += self.connections[connection_node]
-        if loop is None:
-            loop = getattr(protocol_obj, "loop", None)
-        if loop is not None:
-            loop.create_task(self.send_route_advertisement(self.router.get_edges()))
->>>>>>> 943b3d5... refactoring module extraction
+            stats.connected_peers_gauge.dec()
 
     def is_ephemeral(self, id_):
         return (

--- a/receptor/router.py
+++ b/receptor/router.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from .exceptions import ReceptorBufferError, UnrouteableError
 from .messages.framed import FramedMessage
 from .stats import route_counter, route_info
+from .serde import encode
 
 logger = logging.getLogger(__name__)
 

--- a/receptor/router.py
+++ b/receptor/router.py
@@ -1,15 +1,14 @@
-import sys
 import asyncio
 import datetime
 import heapq
-import logging
 import itertools
+import logging
+import sys
 from collections import defaultdict
 
 from .exceptions import ReceptorBufferError, UnrouteableError
 from .messages.framed import FramedMessage
 from .stats import route_counter, route_info
-from .serde import encode
 
 logger = logging.getLogger(__name__)
 

--- a/receptor/serde.py
+++ b/receptor/serde.py
@@ -9,6 +9,7 @@ def decoder(typename):
     def _inner(func):
         decoders[typename] = func
         return func
+
     return _inner
 
 
@@ -21,7 +22,14 @@ def decode(o):
 
 @singledispatch
 def encode(o):
-    return json.JSONEncoder.default(o)
+    return json.JSONEncoder().default(o)
+
+
+def wrapped_encode(o):
+    try:
+        return encode(o)
+    except TypeError:
+        return str(o)
 
 
 @encode.register(datetime.datetime)
@@ -38,3 +46,5 @@ load = partial(json.load, object_hook=decode)
 loads = partial(json.loads, object_hook=decode)
 dump = partial(json.dump, default=encode)
 dumps = partial(json.dumps, default=encode)
+
+force_dumps = partial(json.dumps, default=wrapped_encode)

--- a/receptor/serde.py
+++ b/receptor/serde.py
@@ -1,10 +1,6 @@
-import asyncio
 import datetime
 import json
 from functools import partial, singledispatch
-import types
-import inspect
-import traceback as tb
 
 decoders = {}
 
@@ -29,46 +25,6 @@ def encode(o):
     return json.JSONEncoder().default(o)
 
 
-def wrapped_encode(o):
-    try:
-        return encode(o)
-    except TypeError:
-        return str(o)
-
-
-@encode.register(set)
-def encode_set(s):
-    return list(s)
-
-
-@encode.register(types.FunctionType)
-def encode_function_type(func):
-    return f"{func.__module__}.{func.__qualname__}"
-
-
-@encode.register(asyncio.Task)
-def encode_coroutine_type(task):
-    coro = task._coro
-    mod = "<unknown>"
-    try:
-        mod = inspect.getmodule(coro, coro.cr_code.co_filename)
-        mod = mod.__name__ if mod else "<unknown>"
-    except AttributeError:
-        pass
-
-    out = {"state": task._state, "name": f"{mod}.{coro.__qualname__}", "stack": []}
-
-    try:
-        stack = tb.extract_stack(task.get_stack(limit=5)[0])
-        out["stack"] = [
-            {"filename": fs.filename, "line": fs.line, "lineno": fs.lineno} for fs in stack
-        ]
-    except IndexError:
-        pass
-
-    return out
-
-
 @encode.register(datetime.datetime)
 def encode_date(obj):
     return {"_type": "datetime.datetime", "value": obj.timestamp()}
@@ -83,5 +39,3 @@ load = partial(json.load, object_hook=decode)
 loads = partial(json.loads, object_hook=decode)
 dump = partial(json.dump, default=encode)
 dumps = partial(json.dumps, default=encode)
-
-force_dumps = partial(json.dumps, default=wrapped_encode)

--- a/receptor/stats.py
+++ b/receptor/stats.py
@@ -1,5 +1,6 @@
 from prometheus_client import Counter, Gauge, Info
 
+bytes_recv = Counter("bytes_recv", "Number of bytes received")
 messages_received_counter = Counter("incoming_messages", "Messages received from Receptor Peers")
 connected_peers_gauge = Gauge("connected_peers", "Number of active peer connections")
 work_counter = Counter(

--- a/receptor/work.py
+++ b/receptor/work.py
@@ -2,7 +2,6 @@ import asyncio
 import concurrent.futures
 import datetime
 import logging
-import traceback
 
 import pkg_resources
 
@@ -85,8 +84,7 @@ class WorkManager:
             raise exceptions.InvalidDirectiveAction(f"Invalid action {action} for {namespace}")
         if not getattr(action_method, "receptor_export", False):
             logger.exception(
-                f"""Not allowed to call {action} from {namespace} because
-                it is not marked for export"""
+                f"""Not allowed to call {action} from {namespace} because it is not marked for export"""
             )
             raise exceptions.InvalidDirectiveAction(
                 f"Access denied calling {action} for {namespace}"
@@ -128,11 +126,9 @@ class WorkManager:
                 await self.receptor.router.send(response_message)
 
         except Exception as e:
-            logger.error(
-                f"""Error encountered while handling the response, replying with
-                    an error message ({e})"""
+            logger.exception(
+                """Error encountered while handling the response, replying with an error message"""
             )
-            logger.error(traceback.format_tb(e.__traceback__))
             eof_response = FramedMessage(
                 header=dict(
                     recipient=message.header["sender"],

--- a/receptor/work.py
+++ b/receptor/work.py
@@ -84,7 +84,8 @@ class WorkManager:
             raise exceptions.InvalidDirectiveAction(f"Invalid action {action} for {namespace}")
         if not getattr(action_method, "receptor_export", False):
             logger.exception(
-                f"""Not allowed to call {action} from {namespace} because it is not marked for export"""
+                f"""Not allowed to call {action} from {namespace} """
+                """because it is not marked for export"""
             )
             raise exceptions.InvalidDirectiveAction(
                 f"Access denied calling {action} for {namespace}"

--- a/test/unit/test_serde.py
+++ b/test/unit/test_serde.py
@@ -1,0 +1,13 @@
+import datetime
+
+from receptor.serde import dumps, loads
+
+
+def test_date_serde():
+
+    o = {"now": datetime.datetime.utcnow()}
+
+    serialized = dumps(o)
+    deserialized = loads(serialized)
+
+    assert deserialized == o


### PR DESCRIPTION
Adds a process that produces a periodic exposition of diagnostic data in $DATA_DIR/diagnostics.json.

The data looks something like this:

```json
{
  "config": {
    "default_node_id": "node",
    "default_config": null,
    "default_data_dir": "/Users/jjaggars/.receptor",
    "default_debug": null,
    "default_max_workers": null,
    "default_logging_format": null,
    "auth_server_cert": null,
    "auth_server_key": null,
    "auth_server_ca_bundle": null,
    "auth_client_cert": null,
    "auth_client_key": null,
    "auth_client_verification_ca": null,
    "auth_server_cipher_list": null,
    "auth_client_cipher_list": null,
    "node_listen": null,
    "node_peers": [
      "rnp://localhost:8888"
    ],
    "node_server_disable": true,
    "node_stats_enable": null,
    "node_stats_port": null,
    "node_keepalive_interval": null,
    "node_groups": null,
    "node_ws_extra_headers": null,
    "func": "receptor.entrypoints.run_as_node",
    "ephemeral": false
  },
  "node_id": "node",
  "datetime": "2020-03-27T18:35:35.456782",
  "recent_errors": [
    {
      "@message": "['  File \"/Users/jjaggars/code/receptor/receptor/work.py\", line 102, in handle\\n    action_method, namespace = self.get_action_method(directive)\\n', '  File \"/Users/jjaggars/code/receptor/receptor/work.py\", line 80, in get_action_method\\n    worker_module = self.load_receptor_worker(namespace)\\n', '  File \"/Users/jjaggars/code/receptor/receptor/work.py\", line 35, in load_receptor_worker\\n    raise exceptions.UnknownDirective(f\"Error loading directive handlers for receptor.work\")\\n']",
      "@timestamp": "2020-03-27T18:35:35.456837",
      "@source_host": "Jesses-MBP-2.lan",
      "@fields": {
        "name": "receptor.work",
        "levelname": "ERROR",
        "levelno": 40,
        "pathname": "/Users/jjaggars/code/receptor/receptor/work.py",
        "filename": "work.py",
        "module": "work",
        "lineno": 135,
        "funcName": "handle",
        "created": 1585330427.289694,
        "msecs": 289.69407081604004,
        "relativeCreated": 9191.896915435791,
        "thread": 4703620544,
        "threadName": "MainThread",
        "processName": "MainProcess",
        "process": 92966,
        "node_id": "node",
        "message": "['  File \"/Users/jjaggars/code/receptor/receptor/work.py\", line 102, in handle\\n    action_method, namespace = self.get_action_method(directive)\\n', '  File \"/Users/jjaggars/code/receptor/receptor/work.py\", line 80, in get_action_method\\n    worker_module = self.load_receptor_worker(namespace)\\n', '  File \"/Users/jjaggars/code/receptor/receptor/work.py\", line 35, in load_receptor_worker\\n    raise exceptions.UnknownDirective(f\"Error loading directive handlers for {name}\")\\n']",
        "asctime": "2020-03-27 13:33:47,289"
      }
    },
    {
      "@message": "Error encountered while handling the response, replying with\n                    an error message (Error loading directive handlers for nop)",
      "@timestamp": "2020-03-27T18:35:35.456873",
      "@source_host": "Jesses-MBP-2.lan",
      "@fields": {
        "name": "receptor.work",
        "levelname": "ERROR",
        "levelno": 40,
        "pathname": "/Users/jjaggars/code/receptor/receptor/work.py",
        "filename": "work.py",
        "module": "work",
        "lineno": 133,
        "funcName": "handle",
        "created": 1585330427.286861,
        "msecs": 286.8609428405762,
        "relativeCreated": 9189.063787460327,
        "thread": 4703620544,
        "threadName": "MainThread",
        "processName": "MainProcess",
        "process": 92966,
        "node_id": "node",
        "message": "Error encountered while handling the response, replying with\n                    an error message (Error loading directive handlers for nop)",
        "asctime": "2020-03-27 13:33:47,286"
      }
    }
  ],
  "connections": [
    {
      "address": "127.0.0.1",
      "port": 8888,
      "compression": null,
      "cipher": null,
      "peercert": null,
      "sslcontext": null,
      "closed": false,
      "chunk_size": 65536,
      "node_id": "controller",
      "capabilities": {
        "worker_versions": {
          "receptor_stresstest": "1.0.0",
          "receptor_file": "0.1.0"
        },
        "max_work_threads": 8
      }
    }
  ],
  "routes": {
    "nodes": [
      "controller"
    ],
    "edges": [
      {
        "left": "controller",
        "right": "node",
        "cost": 1
      }
    ],
    "neighbors": [
      {
        "node_id": "controller",
        "items": [
          "node"
        ]
      },
      {
        "node_id": "node",
        "items": [
          "controller"
        ]
      }
    ],
    "table": [
      {
        "destination_node_id": "controller",
        "next_hop": "controller",
        "cost": 1
      }
    ]
  },
  "tasks": [
    {
      "state": "PENDING",
      "items": [
        {
          "name": "receptor.receptor.Receptor.shutdown_handler",
          "stack": [
            {
              "filename": "/Users/jjaggars/code/receptor/receptor/receptor.py",
              "line": "await asyncio.sleep(1)",
              "lineno": 206
            }
          ]
        },
        {
          "name": "receptor.connection.base.Worker.receive",
          "stack": [
            {
              "filename": "/Users/jjaggars/code/receptor/receptor/connection/base.py",
              "line": "async for msg in self.conn:",
              "lineno": 60
            }
          ]
        },
        {
          "name": "receptor.connection.base.Worker.watch_queue",
          "stack": [
            {
              "filename": "/Users/jjaggars/code/receptor/receptor/connection/base.py",
              "line": "item = await asyncio.wait_for(self.outbound.get(), 5.0)",
              "lineno": 104
            }
          ]
        },
        {
          "name": "receptor.connection.sock.connect",
          "stack": [
            {
              "filename": "/Users/jjaggars/code/receptor/receptor/connection/sock.py",
              "line": "await worker.client(t)",
              "lineno": 59
            }
          ]
        },
        {
          "name": "receptor.diagnostics.status",
          "stack": [
            {
              "filename": "/Users/jjaggars/Library/Caches/pypoetry/virtualenvs/receptor-7LbJpkJb-py3.6/bin/receptor",
              "line": "load_entry_point('receptor', 'console_scripts', 'receptor')()",
              "lineno": 11
            }
          ]
        },
        {
          "name": "receptor.buffers.file.DurableBuffer.manifest_writer",
          "stack": [
            {
              "filename": "/Users/jjaggars/code/receptor/receptor/buffers/file.py",
              "line": "await self._manifest_dirty.wait()",
              "lineno": 129
            }
          ]
        },
        {
          "name": "receptor.receptor.Receptor.message_handler",
          "stack": [
            {
              "filename": "/Users/jjaggars/code/receptor/receptor/receptor.py",
              "line": "data = await buf.get()",
              "lineno": 136
            }
          ]
        },
        {
          "name": "receptor.buffers.file.DurableBuffer.get",
          "stack": [
            {
              "filename": "/Users/jjaggars/code/receptor/receptor/buffers/file.py",
              "line": "item = await self.q.get()",
              "lineno": 74
            }
          ]
        },
        {
          "name": "receptor.receptor.Manifest.watch_expire",
          "stack": [
            {
              "filename": "/Users/jjaggars/code/receptor/receptor/receptor.py",
              "line": "await asyncio.sleep(600)",
              "lineno": 58
            }
          ]
        },
        {
          "name": "asyncio.locks.Event.wait",
          "stack": [
            {
              "filename": "/Users/jjaggars/.pyenv/versions/3.6.9/lib/python3.6/asyncio/locks.py",
              "line": "yield from fut",
              "lineno": 283
            }
          ]
        }
      ]
    }
  ],
  "metrics": [
    {
      "name": "python_gc_objects_collected",
      "type": "counter",
      "samples": [
        {
          "name": "python_gc_objects_collected_total",
          "labels": {
            "generation": "0"
          },
          "value": 13615,
          "timestamp": null,
          "exemplar": null
        },
        {
          "name": "python_gc_objects_collected_total",
          "labels": {
            "generation": "1"
          },
          "value": 2610,
          "timestamp": null,
          "exemplar": null
        },
        {
          "name": "python_gc_objects_collected_total",
          "labels": {
            "generation": "2"
          },
          "value": 691,
          "timestamp": null,
          "exemplar": null
        }
      ]
    },
    {
      "name": "python_gc_objects_uncollectable",
      "type": "counter",
      "samples": [
        {
          "name": "python_gc_objects_uncollectable_total",
          "labels": {
            "generation": "0"
          },
          "value": 0,
          "timestamp": null,
          "exemplar": null
        },
        {
          "name": "python_gc_objects_uncollectable_total",
          "labels": {
            "generation": "1"
          },
          "value": 0,
          "timestamp": null,
          "exemplar": null
        },
        {
          "name": "python_gc_objects_uncollectable_total",
          "labels": {
            "generation": "2"
          },
          "value": 0,
          "timestamp": null,
          "exemplar": null
        }
      ]
    },
    {
      "name": "python_gc_collections",
      "type": "counter",
      "samples": [
        {
          "name": "python_gc_collections_total",
          "labels": {
            "generation": "0"
          },
          "value": 125,
          "timestamp": null,
          "exemplar": null
        },
        {
          "name": "python_gc_collections_total",
          "labels": {
            "generation": "1"
          },
          "value": 11,
          "timestamp": null,
          "exemplar": null
        },
        {
          "name": "python_gc_collections_total",
          "labels": {
            "generation": "2"
          },
          "value": 1,
          "timestamp": null,
          "exemplar": null
        }
      ]
    },
    {
      "name": "python_info",
      "type": "gauge",
      "samples": [
        {
          "name": "python_info",
          "labels": {
            "version": "3.6.9",
            "implementation": "CPython",
            "major": "3",
            "minor": "6",
            "patchlevel": "9"
          },
          "value": 1,
          "timestamp": null,
          "exemplar": null
        }
      ]
    },
    {
      "name": "bytes_recv",
      "type": "counter",
      "samples": [
        {
          "name": "bytes_recv_total",
          "labels": {},
          "value": 2948,
          "timestamp": null,
          "exemplar": null
        },
        {
          "name": "bytes_recv_created",
          "labels": {},
          "value": 1585330418.2000089,
          "timestamp": null,
          "exemplar": null
        }
      ]
    },
    {
      "name": "incoming_messages",
      "type": "counter",
      "samples": [
        {
          "name": "incoming_messages_total",
          "labels": {},
          "value": 1,
          "timestamp": null,
          "exemplar": null
        },
        {
          "name": "incoming_messages_created",
          "labels": {},
          "value": 1585330418.2000299,
          "timestamp": null,
          "exemplar": null
        }
      ]
    },
    {
      "name": "connected_peers",
      "type": "gauge",
      "samples": [
        {
          "name": "connected_peers",
          "labels": {},
          "value": 1,
          "timestamp": null,
          "exemplar": null
        }
      ]
    },
    {
      "name": "work_events",
      "type": "counter",
      "samples": [
        {
          "name": "work_events_total",
          "labels": {},
          "value": 0,
          "timestamp": null,
          "exemplar": null
        },
        {
          "name": "work_events_created",
          "labels": {},
          "value": 1585330418.200063,
          "timestamp": null,
          "exemplar": null
        }
      ]
    },
    {
      "name": "active_work",
      "type": "gauge",
      "samples": [
        {
          "name": "active_work",
          "labels": {},
          "value": 0,
          "timestamp": null,
          "exemplar": null
        }
      ]
    },
    {
      "name": "route_events",
      "type": "counter",
      "samples": [
        {
          "name": "route_events_total",
          "labels": {},
          "value": 1,
          "timestamp": null,
          "exemplar": null
        },
        {
          "name": "route_events_created",
          "labels": {},
          "value": 1585330418.200086,
          "timestamp": null,
          "exemplar": null
        }
      ]
    },
    {
      "name": "routing_table",
      "type": "info",
      "samples": [
        {
          "name": "routing_table_info",
          "labels": {
            "edges": "{('controller', 'node', 1)}"
          },
          "value": 1,
          "timestamp": null,
          "exemplar": null
        }
      ]
    },
    {
      "name": "receptor_info",
      "type": "info",
      "samples": [
        {
          "name": "receptor_info_info",
          "labels": {
            "node_id": "node",
            "receptor_version": "1.0.0"
          },
          "value": 1,
          "timestamp": null,
          "exemplar": null
        }
      ]
    },
    {
      "name": "worker_info",
      "type": "info",
      "samples": [
        {
          "name": "worker_info_info",
          "labels": {
            "plugins": "{'worker_versions': {'receptor_stresstest': '1.0.0', 'receptor_file': '0.1.0'}, 'max_work_threads': 8}"
          },
          "value": 1,
          "timestamp": null,
          "exemplar": null
        }
      ]
    }
  ]
}
```