### PR TITLE
Better route broadcasts

### DIFF
--- a/receptor/buffers/file.py
+++ b/receptor/buffers/file.py
@@ -75,7 +75,7 @@ class DurableBuffer:
             self.dirty()
             try:
                 if self.is_expired(item):
-                    self.expire(item)
+                    await self.expire(item)
                     continue
                 return item
             except (TypeError, KeyError):

--- a/receptor/connection/base.py
+++ b/receptor/connection/base.py
@@ -60,6 +60,8 @@ class Worker:
                 if self.conn.closed:
                     break
                 await self.buf.put(msg)
+        except ConnectionResetError:
+            logger.debug("receive: other side closed the connection")
         except asyncio.CancelledError:
             logger.debug("receive: cancel request received")
         except Exception:

--- a/receptor/connection/base.py
+++ b/receptor/connection/base.py
@@ -71,7 +71,7 @@ class Worker:
         await self.receptor.update_connections(self.conn, id_=self.remote_id)
 
     async def unregister(self):
-        await self.receptor.remove_connection(self.conn, id_=self.remote_id, loop=self.loop)
+        await self.receptor.remove_connection(self.conn, id_=self.remote_id)
         self._cancel(self.read_task)
         self._cancel(self.handle_task)
         self._cancel(self.write_task)
@@ -85,7 +85,7 @@ class Worker:
         await self.conn.send(BridgeQueue.one(msg))
 
     async def start_processing(self):
-        await self.receptor.send_route_advertisement()
+        await self.receptor.recalculate_and_send_routes_soon()
         logger.debug("starting normal loop")
         self.handle_task = self.loop.create_task(self.receptor.message_handler(self.buf))
         self.outbound = self.receptor.buffer_mgr[self.remote_id]
@@ -114,7 +114,7 @@ class Worker:
 
         except asyncio.CancelledError:
             logger.debug("watch_queue: cancel request received")
-            self.close()
+            await self.close()
 
     async def drain_buf(self, item):
         try:
@@ -143,6 +143,7 @@ class Worker:
         response = await self.buf.get()  # TODO: deal with timeout
         self.remote_id = response.header["id"]
         await self.register()
+        await self.receptor.recalculate_and_send_routes_soon()
 
     async def client(self, transport):
         try:

--- a/receptor/connection/sock.py
+++ b/receptor/connection/sock.py
@@ -42,8 +42,8 @@ async def connect(host, port, factory, loop=None, ssl=None, reconnect=True):
         log_ssl_detail(w._transport)
         t = RawSocket(r, w)
         await worker.client(t)
-    except Exception:
-        logger.exception("sock.connect")
+    except Exception as ex:
+        logger.info(f"sock.connect: connection failed, {str(ex)}")
         if not reconnect:
             return False
     finally:

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -52,7 +52,7 @@ async def run_oneshot_command(controller, peer, recipient, ws_extra_headers, sen
                 print("Connection failed. Exiting.")
                 return False
             if (recipient and controller.receptor.router.node_is_known(recipient)) or (
-                not recipient and len(controller.receptor.router.get_nodes()) > 1
+                not recipient and controller.receptor.routes_received
             ):
                 break
             if time.time() - start_wait > 5:

--- a/receptor/entrypoints.py
+++ b/receptor/entrypoints.py
@@ -51,10 +51,11 @@ async def run_oneshot_command(controller, peer, recipient, ws_extra_headers, sen
             if add_peer_task and add_peer_task.done() and not add_peer_task.result():
                 print("Connection failed. Exiting.")
                 return False
-            if ((not recipient or controller.receptor.router.node_is_known(recipient)) and
-                controller.receptor.route_send_time is not None and
-                time.time() - controller.receptor.route_send_time > 2.0
-                ):
+            if (
+                (not recipient or controller.receptor.router.node_is_known(recipient))
+                and controller.receptor.route_send_time is not None
+                and time.time() - controller.receptor.route_send_time > 2.0
+            ):
                 break
             if time.time() - start_wait > 10:
                 print("Connection timed out. Exiting.")

--- a/receptor/fileio.py
+++ b/receptor/fileio.py
@@ -1,7 +1,16 @@
+import atexit
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
 pool = ThreadPoolExecutor()
+
+
+def shutdown_pool():
+    for thread in pool._threads:
+        thread._tstate_lock.release()
+
+
+atexit.register(shutdown_pool)
 
 
 class Deferrer:

--- a/receptor/receptor.py
+++ b/receptor/receptor.py
@@ -4,6 +4,7 @@ import logging
 import os
 import time
 import uuid
+import collections
 
 import pkg_resources
 
@@ -82,7 +83,10 @@ class Receptor:
         self.config = config
         self.node_id = node_id or self.config.default_node_id or self._find_node_id()
         self.router = (router_cls or MeshRouter)(self)
-        self.routes_received = False
+        self.route_sender_task = None
+        self.route_send_time = time.time()
+        self.last_sent_seq = None
+        self.route_adv_seen = dict()
         self.work_manager = (work_manager_cls or WorkManager)(self)
         self.connections = dict()
         self.response_queue = response_queue
@@ -93,7 +97,10 @@ class Receptor:
         path = os.path.join(os.path.expanduser(self.base_path))
         self.buffer_mgr = FileBufferManager(path)
         self.stop = False
-        self.node_capabilities = {self.node_id: self.work_manager.get_capabilities()}
+        self.known_nodes = collections.defaultdict(
+            lambda: dict(capabilities=dict(), sequence=0, connections=dict())
+        )
+        self.known_nodes[self.node_id]["capabilities"] = self.work_manager.get_capabilities()
         try:
             receptor_dist = pkg_resources.get_distribution("receptor")
             receptor_version = receptor_dist.version
@@ -132,52 +139,56 @@ class Receptor:
         if id_ is None:
             id_ = protocol_obj.id
 
-        self.router.add_or_update_edges([(id_, self.node_id, 1)])
+        routing_changed = False
         if id_ in self.connections:
-            self.connections[id_].append(protocol_obj)
+            if protocol_obj not in self.connections[id_]:
+                self.connections[id_].append(protocol_obj)
+                routing_changed = True
         else:
             self.connections[id_] = [protocol_obj]
+            routing_changed = True
         await self.connection_manifest.update(id_)
+        if routing_changed:
+            await self.recalculate_and_send_routes_soon()
 
     async def remove_ephemeral(self, node):
         logger.debug(f"Removing ephemeral node {node}")
+        changed = False
         if node in self.connections:
             await self.connection_manifest.remove(node)
-        if node in self.node_capabilities:
-            del self.node_capabilities[node]
-        self.router.remove_node(node)
+            changed = True
+        if node in self.known_nodes:
+            del self.known_nodes[node]
+            changed = True
+        if changed:
+            await self.recalculate_and_send_routes_soon()
 
-    async def remove_connection(self, protocol_obj, id_=None, loop=None):
-        notify_connections = []
+    async def remove_connection(self, protocol_obj, id_=None):
+        routing_changed = False
         for connection_node in self.connections:
             if protocol_obj in self.connections[connection_node]:
-                logger.info(
-                    "Removing connection {} for node {}".format(protocol_obj, connection_node)
-                )
+                routing_changed = True
+                logger.info(f"Removing connection for node {connection_node}")
                 if self.is_ephemeral(connection_node):
                     self.connections[connection_node].remove(protocol_obj)
                     await self.remove_ephemeral(connection_node)
                 else:
                     self.connections[connection_node].remove(protocol_obj)
-                    self.router.add_or_update_edges([(self.node_id, connection_node, 100)])
                     await self.connection_manifest.update(connection_node)
-            notify_connections += self.connections[connection_node]
-        if loop is None:
-            loop = getattr(protocol_obj, "loop", None)
-        if loop is not None:
-            loop.create_task(self.send_route_advertisement())
+        if routing_changed:
+            await self.recalculate_and_send_routes_soon()
 
     def is_ephemeral(self, id_):
         return (
-            id_ in self.node_capabilities
-            and "ephemeral" in self.node_capabilities[id_]
-            and self.node_capabilities[id_]["ephemeral"]
+            id_ in self.known_nodes
+            and "ephemeral" in self.known_nodes[id_]["capabilities"]
+            and self.known_nodes[id_]["capabilities"]["ephemeral"]
         )
 
     async def remove_connection_by_id(self, id_, loop=None):
         if id_ in self.connections:
             for protocol_obj in self.connections[id_]:
-                await self.remove_connection(protocol_obj, id_, loop)
+                await self.remove_connection(protocol_obj, id_)
 
     async def shutdown_handler(self):
         while True:
@@ -199,49 +210,60 @@ class Receptor:
             }
         )
 
-    async def handle_route_advertisement(self, data):
-        if "id" in data:
-            sender = data["id"]
-        else:
-            raise exceptions.UnknownMessageType("Malformed route advertisement: No sender")
-
-        if "cmd" not in data or data["cmd"] != "ROUTE2":
-            raise exceptions.UnknownMessageType(
-                f"Unknown route advertisement protocol received from {sender}")
-
-        if sender not in self.connections:
-            raise exceptions.UnknownMessageType(
-                f"Route advertisement received from unknown sender {sender}")
-
-        logger.debug(f"Route advertisement received From {sender}")
-
-        if "node_capabilities" in data:
-            for node, caps in data["node_capabilities"].items():
-                self.node_capabilities[node] = caps
-
-        old_nodes = set([node for e in self.router.get_edges() for node in e[0:2]])
-        new_nodes = set([node for e in data["edges"] for node in e[0:2]])
-        for removed_node in old_nodes - new_nodes:
-            if self.is_ephemeral(removed_node) and removed_node not in self.connections:
-                await self.remove_ephemeral(removed_node)
-        self.router.add_or_update_edges(data["edges"])
-        await self.send_route_advertisement(exclude_conn=[sender])
-        self.routes_received = True
-
-    async def send_route_advertisement(self, exclude_conn=None):
-        send_conn = set(self.connections)
-        if exclude_conn:
-            send_conn -= set(exclude_conn)
-
-        if send_conn:
-            if not exclude_conn:
-                logger.debug(f"Emitting route advertisements")
-            else:
-                logger.debug(f"Emitting route advertisements, excluding {exclude_conn}")
-
-        for node_id in send_conn:
-            if exclude_conn and node_id in exclude_conn:
+    async def recalculate_routes(self):
+        """Construct local routing table from source data"""
+        edge_costs = dict()
+        logger.debug("Constructing routing table")
+        for node in self.connections:
+            if self.connections[node]:
+                edge_costs[tuple(sorted([self.node_id, node]))] = 1
+        manifest = await self.connection_manifest.get()
+        for node in manifest:
+            node_key = tuple(sorted([self.node_id, node["id"]]))
+            if node_key not in edge_costs:
+                edge_costs[node_key] = 100
+        for node in self.known_nodes:
+            if node == self.node_id:
                 continue
+            for conn, cost in self.known_nodes[node]["connections"].items():
+                node_key = tuple(sorted([node, conn]))
+                if node_key not in edge_costs:
+                    edge_costs[node_key] = cost
+            pass
+        anything_changed = False
+        old_edge_keys = self.router.get_edge_keys()
+        for node_key, cost in edge_costs.items():
+            if node_key in old_edge_keys:
+                old_edge_keys.remove(node_key)
+            if self.router.get_edge_cost(*node_key) != cost:
+                anything_changed = True
+                break
+        if old_edge_keys:
+            anything_changed = True
+        if anything_changed:
+            self.router.add_or_update_edges(
+                [(key[0], key[1], value) for key, value in edge_costs.items()], replace_all=True,
+            )
+            self.known_nodes[self.node_id]["sequence"] += 1
+            logger.debug(f"Routing updated. New table: {self.router.get_edges()}")
+        return anything_changed
+
+    async def send_routes(self):
+        """Send routing update to connected peers"""
+        route_adv_id = str(uuid.uuid4())
+        seq = self.known_nodes[self.node_id]["sequence"]
+        logger.debug(f"Sending route advertisement {route_adv_id} seq {seq}")
+        self.last_sent_seq = seq
+
+        advertised_connections = dict()
+        for node1, node2, cost in self.router.get_edges():
+            other_node = (
+                node1 if node2 == self.node_id else node2 if node1 == self.node_id else None
+            )
+            if other_node:
+                advertised_connections[other_node] = cost
+
+        for node_id in self.connections:
             buf = self.buffer_mgr[node_id]
             try:
                 msg = framed.FramedMessage(
@@ -249,14 +271,119 @@ class Receptor:
                         "cmd": "ROUTE2",
                         "recipient": node_id,
                         "id": self.node_id,
-                        "node_capabilities": self.node_capabilities,
-                        "groups": self.config.node_groups,
-                        "edges": self.router.get_edges(),
+                        "origin": self.node_id,
+                        "route_adv_id": route_adv_id,
+                        "connections": advertised_connections,
+                        "sequence": seq,
+                        "node_capabilities": {
+                            node: value["capabilities"]
+                            for (node, value) in self.known_nodes.items()
+                        },
                     }
                 )
                 await buf.put(msg.serialize())
             except Exception as e:
-                logger.exception("Error trying to broadcast routes and capabilities: {}".format(e))
+                logger.exception("Error trying to send route update: {}".format(e))
+
+    async def route_send_check(self):
+        while time.time() < self.route_send_time:
+            await asyncio.sleep(self.route_send_time - time.time())
+        self.route_sender_task = None
+        routes_changed = await self.recalculate_routes()
+        if routes_changed or self.known_nodes[self.node_id]["sequence"] != self.last_sent_seq:
+            await self.send_routes()
+
+    async def recalculate_and_send_routes_soon(self):
+        self.route_send_time = time.time() + 0.1
+        if not self.route_sender_task:
+            self.route_sender_task = asyncio.ensure_future(self.route_send_check())
+
+    async def handle_route_advertisement(self, data):
+
+        # Sanity checks of the message
+        if "origin" in data:
+            origin = data["origin"]
+        else:
+            raise exceptions.UnknownMessageType("Malformed route advertisement: No origin")
+        if (
+            "cmd" not in data
+            or "route_adv_id" not in data
+            or "sequence" not in data
+            or data["cmd"] != "ROUTE2"
+        ):
+            raise exceptions.UnknownMessageType(
+                f"Unknown route advertisement protocol received from {origin}"
+            )
+        logger.debug(
+            f"Route advertisement {data['route_adv_id']} seq {data['sequence']} "
+            + f"received From {origin} via {data['id']}"
+        )
+
+        # Check if we received an update about ourselves
+        if origin == self.node_id:
+            if data["sequence"] > self.known_nodes[self.node_id]["sequence"]:
+                new_seq = data["sequence"] + 1
+                logger.debug(
+                    f"Updating sequence number to {new_seq} based on received self-reference"
+                )
+                self.known_nodes[self.node_id]["sequence"] = new_seq
+                await self.recalculate_and_send_routes_soon()
+            else:
+                logger.debug(f"Ignoring route advertisement {data['sequence']} from ourselves")
+            return
+
+        # Check that we have not seen this exact update before
+        expire_time = time.time() - 600
+        self.route_adv_seen = {
+            raid: exp for (raid, exp) in self.route_adv_seen.items() if exp > expire_time
+        }
+        if data["route_adv_id"] in self.route_adv_seen:
+            logger.debug(f"Ignoring already-seen route advertisement {data['route_adv_id']}")
+            return
+        self.route_adv_seen[data["route_adv_id"]] = time.time()
+
+        # Check that the sequence number is newer than what we already have
+        if origin in self.known_nodes and self.known_nodes[origin]["sequence"] >= data["sequence"]:
+            logger.warn(
+                f"Ignoring routing update {data['route_adv_id']} from {origin} "
+                + f"seq {data['sequence']} because we already have seq "
+                + f"{self.known_nodes[origin]['sequence']}"
+            )
+            return
+
+        # TODO: don't just assume this is all correct
+        if "node_capabilities" in data:
+            for node, caps in data["node_capabilities"].items():
+                self.known_nodes[node]["capabilities"] = caps
+
+        # Remove any ephemeral nodes that have been dropped from the origin
+        ephems = set()
+        for conn in self.known_nodes[origin]["connections"]:
+            if conn in self.known_nodes and self.is_ephemeral(conn):
+                ephems.add(conn)
+        for ephem in ephems:
+            if ephem not in data["connections"]:
+                logger.debug(f"Removing orphaned ephemeral node {ephem}")
+                del self.known_nodes[ephem]
+
+        # Update our own routing table based on the data we just received
+        self.known_nodes[origin]["connections"] = data["connections"]
+        self.known_nodes[origin]["sequence"] = data["sequence"]
+        await self.recalculate_routes()
+
+        # Re-send the routing update to all our connections except the one it came in on
+        for conn in self.connections:
+            if conn == data["id"]:
+                continue
+            send_data = dict(data)
+            buf = self.buffer_mgr[conn]
+            try:
+                send_data["id"] = self.node_id
+                send_data["recipient"] = conn
+                msg = framed.FramedMessage(header=send_data)
+                await buf.put(msg.serialize())
+            except Exception as e:
+                logger.exception("Error trying to forward route broadcast: {}".format(e))
 
     async def handle_directive(self, msg):
         try:

--- a/receptor/receptor.py
+++ b/receptor/receptor.py
@@ -82,6 +82,7 @@ class Receptor:
         self.config = config
         self.node_id = node_id or self.config.default_node_id or self._find_node_id()
         self.router = (router_cls or MeshRouter)(self)
+        self.routes_received = False
         self.work_manager = (work_manager_cls or WorkManager)(self)
         self.connections = dict()
         self.response_queue = response_queue
@@ -225,6 +226,7 @@ class Receptor:
                 await self.remove_ephemeral(removed_node)
         self.router.add_or_update_edges(data["edges"])
         await self.send_route_advertisement(exclude_conn=[sender])
+        self.routes_received = True
 
     async def send_route_advertisement(self, exclude_conn=None):
         send_conn = set(self.connections)

--- a/receptor/receptor.py
+++ b/receptor/receptor.py
@@ -337,7 +337,7 @@ class Receptor:
             return
         self.route_adv_seen[data["route_adv_id"]] = time.time()
 
-        # If this is the first time we've seen this node, advertise ourselves so it can know we exist
+        # If this is the first time we've seen this node, advertise ourselves to it
         if origin not in self.known_nodes:
             await self.recalculate_and_send_routes_soon(force_send=True)
 
@@ -349,7 +349,8 @@ class Receptor:
             logger.warn(
                 f"Ignoring routing update {data['route_adv_id']} from {origin} "
                 + f"epoch {data['seq_epoch']} seq {data['sequence']} because we already have "
-                + f"epoch {self.known_nodes[origin]['seq_epoch']} seq {self.known_nodes[origin['sequence']]}"
+                + f"epoch {self.known_nodes[origin]['seq_epoch']} "
+                + f"seq {self.known_nodes[origin['sequence']]}"
             )
             return
 

--- a/receptor/router.py
+++ b/receptor/router.py
@@ -72,12 +72,16 @@ class MeshRouter:
     def node_is_known(self, node_id):
         return node_id in self._nodes or node_id == self.node_id
 
-    def add_or_update_edges(self, edges):
+    def add_or_update_edges(self, edges, replace_all=False):
         """
         Adds a list of edges supplied as (node1, node2, cost) tuples.
         Already-existing edges have their cost updated.
         Supplying a cost of None removes the edge.
         """
+        if replace_all:
+            self._nodes = set()
+            self._edges = dict()
+            self._neighbors = defaultdict(set)
         for left, right, cost in edges:
             edge_key = tuple(sorted([left, right]))
             if edge_key not in self._edges:
@@ -107,6 +111,10 @@ class MeshRouter:
         if node in self._nodes:
             self._nodes.remove(node)
         route_info.info(dict(edges=str(set(self.get_edges()))))
+
+    def get_edge_keys(self):
+        """Returns list of edge keys as sorted node-pair tuples"""
+        return set(self._edges.keys())
 
     def get_edges(self):
         """Returns set of edges as a list of (node1, node2, cost) tuples."""

--- a/receptor/router.py
+++ b/receptor/router.py
@@ -187,7 +187,8 @@ class MeshRouter:
         Forward a message on to the next hop closer to its destination
         """
         buffer_obj = self.receptor.buffer_mgr[next_hop]
-        msg.header["route_list"].append(self.node_id)
+        if "route_list" not in msg.header or msg.header["route_list"][-1] != self.node_id:
+            msg.header["route_list"].append(self.node_id)
         logger.debug(f"Forwarding frame {msg.msg_id} to {next_hop}")
         try:
             route_counter.inc()

--- a/receptor/work.py
+++ b/receptor/work.py
@@ -158,5 +158,3 @@ class WorkManager:
                 )
             )
         await self.receptor.router.send(eof_response)
-        if self.receptor.is_ephemeral(message.header["sender"]):
-            await self.receptor.remove_connection_by_id(message.header["sender"])


### PR DESCRIPTION
In the existing implementation, each node sends _its own_ information to _all nodes_.  This creates an inherent tension where constructing the routing table relies on the existence of the very routing table we're trying to construct, leading to various instabilities, race conditions and problems.

This PR changes the behavior so that we send _everything we know_ to _direct peers_, who then repeat the message to their own peers in a fan-out arrangement.  This is more robust because a given node is always in a position to know for sure what its own local connections are.

Because this change requires a different message format ("seen" is gone, etc), the new-style routing messages are labeled `ROUTE2`.  In the case where old-protocol nodes attempt to join a network with new-protocol nodes, the new-protocol nodes will log error messages.  No attempt is made to allow interoperability between the two routing protocols.