### PR TITLE
Fix several docstring warnings

### DIFF
--- a/receptor/controller.py
+++ b/receptor/controller.py
@@ -104,7 +104,7 @@ class Controller:
     async def recv(self):
         """
         Fetch a single response message from the response queue, this method blocks
-        and should be *await*ed or assigned to a Future
+        and should be *await* ed or assigned to a Future
 
         :return: A single response message
         :rtype: :class:`receptor.messages.framed.FramedMessage`

--- a/receptor/messages/framed.py
+++ b/receptor/messages/framed.py
@@ -2,19 +2,19 @@
 This module provides classes to build framed messages as well as consume a
 stream of framed messages into descrete messages.
 
-There are two configurations of framed messages, single and dual part:
+There are two configurations of framed messages, single and dual part::
 
-FramedMessage--------------------------------
-    Frame (Header)
-    {json data}
-    Frame (Payload)
-    FileBackedBuffer
----------------------------------------------
+    FramedMessage--------------------------------
+        Frame (Header)
+        {json data}
+        Frame (Payload)
+        FileBackedBuffer
+    ---------------------------------------------
 
-FramedMessage--------------------------------
-    Frame (Command)
-    {json data}
----------------------------------------------
+    FramedMessage--------------------------------
+        Frame (Command)
+        {json data}
+    ---------------------------------------------
 """
 import asyncio
 import functools


### PR DESCRIPTION
Building the docs produces the following warnings:

    …/receptor/controller.py:docstring of receptor.controller.Controller.recv:1: WARNING: Inline emphasis start-string without end-string.
    …/receptor/messages/framed.py:docstring of receptor.messages.framed:11: WARNING: Definition list ends without a blank line; unexpected unindent.
    …/receptor/messages/framed.py:docstring of receptor.messages.framed:16: WARNING: Definition list ends without a blank line; unexpected unindent.
    …/docs/source/modules.rst: WARNING: document isn't included in any toctree

Fix the first three. The solution to the fourth isn't immediately
obvious to me, and fixing it requires a knowledge of the developers'
intent.

Issues like this can be more easily detected by building docs as part of
CI and setting `nitpicky = True` in `docs/conf.py`.