### PR TITLE
Add pre-commit config for flake8 hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+      - id: flake8


### PR DESCRIPTION
Add config file for using https://pre-commit.com/ hooks to run flake8 on git commit.  To use this, pip/yum/dnf install pre-commit, then run `pre-commit install`.  To not use this, don't do anything.