### PR TITLE
Add a timeout for waiting on the HI response from the peer node.

### DIFF
--- a/receptor/connection/base.py
+++ b/receptor/connection/base.py
@@ -142,7 +142,7 @@ class Worker:
 
     async def _wait_handshake(self):
         logger.debug("waiting for HI")
-        response = await asyncio.wait_for(self.buf.get(), 5.0)
+        response = await self.buf.get(timeout=5.0)
         self.remote_id = response.header["id"]
         await self.register()
         await self.receptor.recalculate_and_send_routes_soon()

--- a/receptor/connection/base.py
+++ b/receptor/connection/base.py
@@ -142,7 +142,7 @@ class Worker:
 
     async def _wait_handshake(self):
         logger.debug("waiting for HI")
-        response = await self.buf.get(timeout=5.0)
+        response = await self.buf.get(timeout=20.0)
         self.remote_id = response.header["id"]
         await self.register()
         await self.receptor.recalculate_and_send_routes_soon()

--- a/receptor/connection/base.py
+++ b/receptor/connection/base.py
@@ -142,7 +142,7 @@ class Worker:
 
     async def _wait_handshake(self):
         logger.debug("waiting for HI")
-        response = await self.buf.get()  # TODO: deal with timeout
+        response = await asyncio.wait_for(self.buf.get(), 5.0)
         self.remote_id = response.header["id"]
         await self.register()
         await self.receptor.recalculate_and_send_routes_soon()

--- a/receptor/messages/framed.py
+++ b/receptor/messages/framed.py
@@ -287,8 +287,8 @@ class FramedBuffer:
         self.to_read = 0
         self.bb = FileBackedBuffer.from_temp()
 
-    async def get(self):
-        return await self.q.get()
+    async def get(self, timeout=None):
+        return await asyncio.wait_for(self.q.get(), timeout)
 
     def get_nowait(self):
         return self.q.get_nowait()


### PR DESCRIPTION
This is a potential fix for Issue #199.

I looked at adding timeout=x and read_timeout=x to the ws_client() call. These parameters do cause a timeout exception to be raised but its not clear to me how to propagate the Timeout exception from the read_task coroutine to the _wait_handshake() method (I believe the exception would have to be placed in the buffer?). Using those parameters also appear to cause the normal socket reading logic to receive a timeout as the coroutine just blocks indefinitely waiting on data to be read from the socket.

This approach is the most surgical approach that I can come up with. Let me know if there is a better approach.