### PR TITLE
Fix file buffers so work.py interface can function as intended

### DIFF
--- a/receptor/messages/framed.py
+++ b/receptor/messages/framed.py
@@ -109,9 +109,8 @@ class FileBackedBuffer:
         self._max_chunk = max_chunk
 
     @classmethod
-    def from_temp(cls, dir=None, delete=False):
-        # return cls(tempfile.NamedTemporaryFile(dir=dir, delete=delete))
-        return cls(tempfile.SpooledTemporaryFile(dir=dir, max_size=2 ** 12))
+    def from_temp(cls, dir=None, delete=True):
+        return cls(tempfile.NamedTemporaryFile(dir=dir, delete=delete))
 
     @classmethod
     def from_buffer(cls, buffered_io, dir=None, delete=False):
@@ -120,7 +119,7 @@ class FileBackedBuffer:
         return cls(fp=buffered_io, length=buffered_io.getbuffer().nbytes)
 
     @classmethod
-    def from_data(cls, raw_data, dir=None, delete=False):
+    def from_data(cls, raw_data, dir=None, delete=True):
         if isinstance(raw_data, str):
             raw_data = raw_data.encode()
         fbb = cls.from_temp(dir=dir, delete=delete)
@@ -128,7 +127,7 @@ class FileBackedBuffer:
         return fbb
 
     @classmethod
-    def from_dict(cls, raw_data, dir=None, delete=False):
+    def from_dict(cls, raw_data, dir=None, delete=True):
         try:
             d = json.dumps(raw_data).encode("utf-8")
         except Exception as e:
@@ -172,6 +171,9 @@ class FileBackedBuffer:
             return self.fp.read()
         finally:
             self.fp.seek(pos)
+
+    def flush(self):
+        self.fp.flush()
 
     def __len__(self):
         return self.length

--- a/receptor/work.py
+++ b/receptor/work.py
@@ -71,6 +71,7 @@ class WorkManager:
             payload.seek(0)
             return payload
         elif payload_type == FILE_PAYLOAD:
+            payload.flush()
             return payload.name
         return payload.readall()
 


### PR DESCRIPTION
Currently, the `FileBackedBuffer` class uses `SpooledTemporaryFile` as its file mechanism.  This is a good choice for performance (although perhaps counterintuitive in a class whose name implies it is always file-backed), but it poses two problems:

1. If this file is to be passed to a worker plugin using `receptor.FILE_PAYLOAD`, then we have to make sure it is fully saved to the filesystem before passing the filename to the worker.
2. In order to pass the filename to the worker, the temporary file needs to _have_ a filename in the first place.

Problem 1 is solvable by calling `fp.rollover()` at the appropriate time, only in the case where `fp is SpooledTemporaryFile` is true.

Problem 2 is not solvable.  `SpooledTemporaryFile`, like `TemporaryFile`, unlinks the file upon creation, so it does not actually have a filename that can be referred to by the plugin.  If we want to pass the filename to worker plugins, we have to use `NamedTemporaryFile`, and unfortunately there is no class in the standard library that gives both spooling and named-file behavior.

It also turns out that, even though there is a scheme for passing around `delete` parameter, we were ignoring it because `SpooledTemporaryFile` does not accept this option (it always deletes).  I have switched the default to `delete=True`, which is also the default of the underlying implementation, and gives the behavior we had been getting with `SpooledTemporaryFile`.