### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description_content_type='text/markdown',
     python_requires=">=3.6",
     install_requires=[
-        "prometheus_client>=0.7.1,<0.9",
+        "prometheus_client>=0.7.1",
         "aiohttp>=3.6.2,<4.0",
         "python-dateutil>=2.8.1",
     ],


### PR DESCRIPTION
 Remove <0.9 restriction on prometheus_client. This is causing issues when trying to run with iqe-tests which requires prometheus_client-0.11